### PR TITLE
Add Kibana version checks and force override

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -824,7 +824,7 @@ dependencies = [
 
 [[package]]
 name = "kibana-object-manager"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "base64",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -836,6 +836,7 @@ dependencies = [
  "owo-colors",
  "regex",
  "reqwest",
+ "semver",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kibana-object-manager"
-version = "0.1.2"
+version = "0.2.0"
 edition = "2024"
 default-run = "kibob"
 rust-version = "1.89"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ reqwest = { version = "^0.13", features = ["json", "multipart", "query"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
 serde_yaml = "0.9"
+semver = "1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync"] }
 url = "^2.5.0"
 

--- a/openspec/changes/kibana-versions/.openspec.yaml
+++ b/openspec/changes/kibana-versions/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-27

--- a/openspec/changes/kibana-versions/design.md
+++ b/openspec/changes/kibana-versions/design.md
@@ -1,0 +1,102 @@
+## Context
+
+Kibob targets multiple Kibana versions, but API surface area differs by release. Saved objects and spaces are broadly available across the supported floor (8.0+), while `agent_builder/agents` and `agent_builder/tools` appeared as tech preview in 9.2 and reached GA in 9.3. Workflows APIs were introduced as tech preview in 9.3. Current pull/push/add flows can attempt unsupported endpoints and fail when users run against older Kibana clusters.
+
+This change is cross-cutting: API orchestration lives in `src/cli.rs`, endpoint implementations live in extractor/loader modules, and request plumbing lives in the Kibana client layer. A single version-gating mechanism is needed so all flows evaluate support consistently.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Detect Kibana server version once and reuse it across command execution.
+- Define a single API support matrix with minimum version per API family.
+- Run a version preflight before command execution and avoid issuing unsupported API requests.
+- Keep `saved_objects` and `spaces` always enabled for supported versions (8.0+).
+- Make skip decisions visible through logs and command summaries, and return warning exit status when unsupported APIs are requested.
+- Persist the source cluster version in `spaces.yml` during pull and enforce push compatibility against that recorded version.
+- Surface minimum version + tech preview status for each API in CLI help and documentation.
+- Provide an explicit `--force` escape hatch for advanced users to bypass version checks with clear warning output.
+- Cover boundary versions in tests (8.x, 9.2.x, 9.3.x).
+
+**Non-Goals:**
+- Backport support below Kibana 8.0.
+- Change payload schemas for supported endpoints.
+- Enforce feature maturity policy (tech preview vs GA) beyond minimum-version gating.
+- Add runtime dependency on external semver CLI tooling.
+
+## Decisions
+
+### 1) Add a normalized Kibana version model in client layer
+- Decision: introduce a small internal `KibanaVersion` value type (major/minor/patch) parsed from Kibana info endpoint data and stored on `KibanaClient`.
+- Rationale: command flows and API modules need consistent comparisons without repeatedly parsing strings.
+- Alternatives considered:
+  - Parse version strings ad hoc in each module: rejected due to duplication and drift risk.
+  - Gate by trial-and-error (call endpoint, treat 404 as unsupported): rejected because it mixes capability detection with transient failures and generates noisy errors.
+
+### 2) Centralize API minimum versions in an enum-backed matrix
+- Decision: define an `ApiCapability` (or equivalent) with minimum supported versions:
+  - `spaces`: 8.0.0
+  - `saved_objects`: 8.0.0
+  - `agents`: 9.2.0
+  - `tools`: 9.2.0
+  - `workflows`: 9.3.0
+- Rationale: one authoritative mapping prevents inconsistencies between pull/push/add/bundle/dependency flows.
+- Alternatives considered:
+  - Hard-code thresholds in each command path: rejected due to maintenance cost.
+  - Load thresholds from config: rejected for now because requirements are product-defined and static.
+
+### 3) Perform mandatory preflight gating before API module invocation
+- Decision: evaluate support in orchestration paths (`pull`, `push`, `add`, dependency enrichment, and bundle/togo) before creating extractor/loader work for any API.
+- Rationale: preflight guarantees consistent behavior, prevents unsupported requests, and allows warning status decisions to be made deterministically.
+- Alternatives considered:
+  - Gate inside each extractor/loader: rejected because command summaries would require additional plumbing and modules would still be constructed.
+
+### 4) Return warning status for unsupported requested APIs
+- Decision: unsupported requested APIs are skipped with structured log lines and completion summaries, and commands return a warning exit status when any requested API is unsupported.
+- Rationale: this preserves partial usefulness for supported APIs while still making version mismatch actionable in automation.
+- Alternatives considered:
+  - Silent skip with success exit status: rejected because unsupported requests can be missed in CI or scripted usage.
+
+### 5) Persist and enforce cluster version provenance via `spaces.yml`
+- Decision: write `kibana.version` (full semver) to `spaces.yml` after pull, then require push target version to be compatible with recorded version (same major with equal/newer minor, or newer major; patch differences ignored for compatibility check).
+- Rationale: prevents accidental pushes from newer-exported object sets into older clusters with missing capabilities.
+- Alternatives considered:
+  - Store version in a separate state file: rejected because `spaces.yml` already acts as cluster/project metadata.
+  - Require exact semver match for push: rejected because patch-level drift is acceptable and common.
+
+### 6) Use versioned API request profiles where docs indicate behavior drift
+- Decision: maintain request profile mappings keyed by capability/version band so tech preview and GA differences can be encoded without scattering conditionals.
+- Rationale: keeps API differences explicit, testable, and easy to revise as documentation evolves.
+- Alternatives considered:
+  - Single request shape for all versions: rejected because tech preview to GA transitions may change payload constraints or endpoints.
+
+### 7) Add `--force` override for version checks
+- Decision: introduce `--force` on relevant commands so users can bypass version preflight and push compatibility floor checks, with explicit warnings that behavior is unsupported.
+- Rationale: provides an intentional escape hatch for edge cases and debugging without weakening default safety.
+- Alternatives considered:
+  - No override: rejected because it blocks operators who need to test undocumented compatibility.
+
+## Risks / Trade-offs
+
+- [Risk] Kibana version format may include suffixes (e.g., snapshot labels) that break strict parsing. -> Mitigation: parse numeric components defensively and ignore suffix metadata.
+- [Risk] Gating logic could diverge between command paths if some flow bypasses centralized helpers. -> Mitigation: expose one helper API and require all orchestrators to call it.
+- [Risk] Users may not realize APIs were skipped. -> Mitigation: print concise skip reason with required vs detected version and include counts in final summary.
+- [Risk] `spaces.yml` schema evolution may break backward compatibility with existing projects. -> Mitigation: add backward-compatible parsing where missing `kibana.version` is treated as unknown and triggers safe fallback messaging.
+- [Risk] `--force` may cause partial writes or API errors on unsupported versions. -> Mitigation: print high-visibility warnings and preserve normal error handling/reporting.
+- [Trade-off] Central matrix increases upfront refactor surface but reduces long-term drift and bug risk.
+
+## Migration Plan
+
+1. Add version retrieval and parsing to Kibana client initialization path.
+2. Introduce capability matrix and helper methods (`is_supported`, `unsupported_reason`).
+3. Wire gating into command orchestration and dependency resolution paths.
+4. Add `spaces.yml` read/write support for `kibana.version` and push compatibility checks.
+5. Add `--force` CLI wiring to bypass preflight/push floor checks with explicit warnings.
+6. Update logs/summaries/help text to include required minimum versions and warning status semantics.
+7. Add tests for version boundaries, warning exits, `--force`, and push compatibility floors.
+8. Validate existing supported-version behavior remains unchanged.
+
+Rollback strategy: revert to previous execution paths by removing capability checks while retaining unrelated refactors. No persistent data migration is required.
+
+## Open Questions
+
+- None currently.

--- a/openspec/changes/kibana-versions/proposal.md
+++ b/openspec/changes/kibana-versions/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+Kibana APIs in scope do not exist uniformly across supported versions, but the CLI currently attempts all selected APIs regardless of server version. We need deterministic version gating so operations succeed from Kibana 8.0 onward without unsupported endpoint failures.
+
+## What Changes
+
+- Add Kibana version detection and an API availability matrix keyed by minimum supported version and maturity milestone.
+- Require a Kibana version preflight check before command execution and gate API execution for `agents`, `tools`, and `workflows` based on detected Kibana version.
+- Keep `saved_objects` and `spaces` enabled across supported versions (8.0+).
+- Skip unsupported APIs with clear logs/summaries, and return a warning exit status when any requested API is unsupported for the target Kibana version.
+- Add a `--force` CLI argument to bypass version checks (with warning) and attempt API calls anyway.
+- Apply gating consistently across pull, push, add, dependency fetch, and bundle/togo flows.
+- Persist `kibana.version: <full-semver>` in `spaces.yml` after pull.
+- Block push to a target Kibana cluster older than the recorded `kibana.version` minor compatibility floor (equal/newer minor allowed; patch differences allowed).
+- Document API minimum versions and tech preview status in CLI help and project documentation for each API.
+- Validate and encode version-specific API request profiles where tech preview and GA behavior differ.
+- Add tests covering boundary versions and mixed API selections.
+
+## Capabilities
+
+### New Capabilities
+- `workflows`: Define version-aware behavior for workflows APIs (introduced as tech preview in 9.3) so unsupported versions are skipped cleanly.
+
+### Modified Capabilities
+- `kibana-client`: Add server version discovery and reusable API support checks.
+- `agents`: Require version-gated access to `agent_builder/agents` (tech preview in 9.2, GA in 9.3).
+- `tools`: Require version-gated access to `agent_builder/tools` (tech preview in 9.2, GA in 9.3).
+- `cli`: Require command preflight gating, warning exit behavior for unsupported requests, and `spaces.yml` Kibana version provenance/push guardrails.
+
+## Impact
+
+- Affected code: `src/kibana/client.rs`, API extractors/loaders for agents/tools/workflows, and orchestration in `src/cli.rs`.
+- Behavioral impact: mixed-version compatibility improves; unsupported API requests are identified up front with warning exits, and push compatibility is guarded by recorded pull version.
+- Test impact: add version matrix tests for 8.x, 9.2, and 9.3 boundary behavior.

--- a/openspec/changes/kibana-versions/specs/agents/spec.md
+++ b/openspec/changes/kibana-versions/specs/agents/spec.md
@@ -1,0 +1,33 @@
+## MODIFIED Requirements
+
+### Requirement: Agent API Compliance
+The system SHALL interact with the Kibana Agents API using the correct conventions for creation and updates, and SHALL only execute these operations when Kibana version is 9.2.0 or newer.
+
+#### Scenario: Create Agent
+- **WHEN** creating a new agent on Kibana 9.2.0 or newer
+- **THEN** the system sends a `POST` request to `/api/agent_builder/agents`
+- **AND** the request body includes the `id`
+- **AND** the request body DOES NOT include `readonly` or `schema` fields
+
+#### Scenario: Update Agent
+- **WHEN** updating an existing agent on Kibana 9.2.0 or newer
+- **THEN** the system sends a `PUT` request to `/api/agent_builder/agents/{id}`
+- **AND** the request body DOES NOT include `id`, `readonly`, or `schema` fields
+
+#### Scenario: Skip agent operations on unsupported Kibana versions
+- **WHEN** an agent operation is requested and Kibana version is lower than 9.2.0
+- **THEN** the system SHALL skip calls to `/api/agent_builder/agents` endpoints
+- **AND** the system SHALL report that agents require Kibana 9.2.0+
+
+## ADDED Requirements
+
+### Requirement: Agent API Version Profile Selection
+The system SHALL apply the agent API request profile that matches the connected Kibana version.
+
+#### Scenario: Use tech preview profile on Kibana 9.2.x
+- **WHEN** the system executes agent operations against Kibana 9.2.x
+- **THEN** the system SHALL use the agent API endpoint/payload profile documented for 9.2 tech preview behavior
+
+#### Scenario: Use GA profile on Kibana 9.3.x and newer
+- **WHEN** the system executes agent operations against Kibana 9.3.x or newer
+- **THEN** the system SHALL use the agent API endpoint/payload profile documented for GA behavior

--- a/openspec/changes/kibana-versions/specs/cli/spec.md
+++ b/openspec/changes/kibana-versions/specs/cli/spec.md
@@ -1,0 +1,80 @@
+## MODIFIED Requirements
+
+### Requirement: API Filtering
+The CLI SHALL support filtering operations by API type using the `--api` flag on `pull`, `push`, and `togo` commands, and SHALL apply Kibana version preflight checks before performing API operations.
+
+#### Scenario: Default behavior (no filter)
+- **WHEN** the user runs `kibob pull` without the `--api` flag
+- **THEN** the system evaluates all supported object types (Spaces, Saved Objects, Workflows, Agents, Tools)
+- **AND** the system gates each API by its minimum supported Kibana version
+
+#### Scenario: Filter by single API
+- **WHEN** the user runs `kibob pull --api tools`
+- **THEN** the system ONLY evaluates Tools
+- **AND** the system skips Tools with a version-gate message if Kibana version is lower than 9.2.0
+
+#### Scenario: Filter by multiple APIs
+- **WHEN** the user runs `kibob push --api agents,workflows`
+- **THEN** the system evaluates Agents and Workflows
+- **AND** the system runs each API only if its minimum Kibana version is met
+- **AND** the system reports skipped APIs in command output
+
+#### Scenario: API Aliases
+- **WHEN** the user uses singular aliases (e.g., `tool`, `agent`, `object`)
+- **THEN** the system treats them as their plural counterparts (`tools`, `agents`, `saved_objects`)
+- **AND** version gating is applied to the normalized API names
+
+#### Scenario: Warning exit status on unsupported requested APIs
+- **WHEN** a command includes one or more APIs unsupported by the connected Kibana version
+- **THEN** the system SHALL perform version checks before sending API requests
+- **AND** the system SHALL return a warning exit status after execution
+
+#### Scenario: Force flag bypasses API version preflight
+- **WHEN** the user runs a command with `--force`
+- **THEN** the system SHALL bypass API minimum-version preflight blocks
+- **AND** the system SHALL print a warning that unsupported API calls may fail
+
+### Requirement: Spaces Manifest Generation
+The `add spaces` command SHALL automatically generate or update the `spaces.yml` manifest file in the project root directory, and pull flows SHALL maintain Kibana version provenance in this file.
+
+#### Scenario: Generate spaces.yml
+- **GIVEN** no `spaces.yml` exists
+- **WHEN** the user runs `kibob add spaces .`
+- **THEN** the system creates `spaces.yml` in the project root
+- **AND** populates it with all spaces found in Kibana
+
+#### Scenario: Record Kibana version on pull
+- **WHEN** the user runs a successful `kibob pull`
+- **THEN** the system updates root `spaces.yml` with `kibana.version: <full-semver>`
+- **AND** the recorded version reflects the Kibana cluster used for that pull
+
+## ADDED Requirements
+
+### Requirement: Push Version Floor Enforcement
+The CLI SHALL block push operations to clusters older than the version recorded in `spaces.yml`.
+
+#### Scenario: Block push to older minor version
+- **GIVEN** `spaces.yml` contains `kibana.version: 9.3.2`
+- **WHEN** the user runs `kibob push` against Kibana `9.2.7`
+- **THEN** the system SHALL abort push before object API calls
+- **AND** the system SHALL return a warning exit status describing version incompatibility
+
+#### Scenario: Allow push with patch drift on same minor
+- **GIVEN** `spaces.yml` contains `kibana.version: 9.3.2`
+- **WHEN** the user runs `kibob push` against Kibana `9.3.0`
+- **THEN** the system SHALL allow push
+- **AND** patch-level differences SHALL NOT block execution
+
+#### Scenario: Force flag bypasses push version floor
+- **GIVEN** `spaces.yml` contains `kibana.version: 9.3.2`
+- **WHEN** the user runs `kibob push --force` against Kibana `9.2.7`
+- **THEN** the system SHALL continue with push attempts
+- **AND** the system SHALL print a warning that version-floor protection was bypassed
+
+### Requirement: API Version Guidance in Help and Docs
+The CLI help output and project documentation SHALL include per-API minimum Kibana versions and tech preview markers.
+
+#### Scenario: API help lists minimum version
+- **WHEN** the user reads CLI help for API selection
+- **THEN** each API entry SHALL include its minimum supported Kibana version
+- **AND** APIs in tech preview SHALL be labeled as tech preview

--- a/openspec/changes/kibana-versions/specs/kibana-client/spec.md
+++ b/openspec/changes/kibana-versions/specs/kibana-client/spec.md
@@ -1,0 +1,39 @@
+## ADDED Requirements
+
+### Requirement: Kibana Version Discovery
+The `KibanaClient` SHALL discover and expose the Kibana server version for use by command orchestration and API modules.
+
+#### Scenario: Version is available after client initialization
+- **WHEN** a `KibanaClient` is created successfully
+- **THEN** the client SHALL store a normalized Kibana version value
+- **AND** downstream code SHALL be able to query that version without additional HTTP calls
+
+### Requirement: API Capability Matrix
+The `KibanaClient` SHALL provide centralized API support checks using minimum-version thresholds.
+
+#### Scenario: Support check for always-supported APIs
+- **WHEN** the system checks support for `spaces` or `saved_objects`
+- **THEN** the check SHALL return supported for Kibana 8.0.0 and newer
+
+#### Scenario: Support check for agents and tools
+- **WHEN** the system checks support for `agents` or `tools`
+- **THEN** the check SHALL return unsupported when Kibana version is lower than 9.2.0
+- **AND** the check SHALL return supported when Kibana version is 9.2.0 or newer
+
+#### Scenario: Support check for workflows
+- **WHEN** the system checks support for `workflows`
+- **THEN** the check SHALL return unsupported when Kibana version is lower than 9.3.0
+- **AND** the check SHALL return supported when Kibana version is 9.3.0 or newer
+
+### Requirement: Versioned API Request Profiles
+The `KibanaClient` SHALL provide version-aware request profile selection for APIs that may differ between tech preview and GA releases.
+
+#### Scenario: Resolve request profile by capability and Kibana version
+- **WHEN** an API module requests request profile metadata for a capability
+- **THEN** the client SHALL resolve profile data using detected Kibana version and capability
+- **AND** the returned profile SHALL include endpoint and payload guidance used by that module
+
+#### Scenario: Use GA profile on or after GA version
+- **WHEN** Kibana version is at or above an API's GA threshold
+- **THEN** the client SHALL return the GA request profile for that capability
+- **AND** API modules SHALL use the GA endpoint/payload mapping for requests

--- a/openspec/changes/kibana-versions/specs/tools/spec.md
+++ b/openspec/changes/kibana-versions/specs/tools/spec.md
@@ -1,0 +1,32 @@
+## MODIFIED Requirements
+
+### Requirement: Tools Push Support
+The system SHALL support pushing tool definitions to Kibana via the `/api/agent_builder/tools` API, correctly handling JSON5 files with multiline strings, and SHALL only execute tools operations when Kibana version is 9.2.0 or newer.
+
+#### Scenario: Push successfully reads and uploads tools
+- **WHEN** the user runs `kibob push` with tools in the project directory on Kibana 9.2.0 or newer
+- **THEN** the system reads the tool JSON files, including those with triple-quoted multiline strings
+- **AND** successfully creates or updates the tools in Kibana
+
+#### Scenario: Roundtrip preservation of multiline queries
+- **GIVEN** a tool with a multiline query (e.g. ES|QL)
+- **WHEN** the tool is pulled and then pushed back on Kibana 9.2.0 or newer
+- **THEN** the query content is preserved exactly as is, without corruption of newlines or special characters
+
+#### Scenario: Skip tools operations on unsupported Kibana versions
+- **WHEN** a tools operation is requested and Kibana version is lower than 9.2.0
+- **THEN** the system SHALL skip calls to `/api/agent_builder/tools` endpoints
+- **AND** the system SHALL report that tools require Kibana 9.2.0+
+
+## ADDED Requirements
+
+### Requirement: Tools API Version Profile Selection
+The system SHALL apply the tools API request profile that matches the connected Kibana version.
+
+#### Scenario: Use tech preview profile on Kibana 9.2.x
+- **WHEN** the system executes tools operations against Kibana 9.2.x
+- **THEN** the system SHALL use the tools endpoint/payload profile documented for 9.2 tech preview behavior
+
+#### Scenario: Use GA profile on Kibana 9.3.x and newer
+- **WHEN** the system executes tools operations against Kibana 9.3.x or newer
+- **THEN** the system SHALL use the tools endpoint/payload profile documented for GA behavior

--- a/openspec/changes/kibana-versions/specs/workflows/spec.md
+++ b/openspec/changes/kibana-versions/specs/workflows/spec.md
@@ -1,0 +1,22 @@
+## ADDED Requirements
+
+### Requirement: Workflows API Version Gating
+The system SHALL treat workflows APIs as supported only when Kibana server version is 9.3.0 or newer.
+
+#### Scenario: Skip workflows on unsupported Kibana versions
+- **WHEN** the user runs a workflow-related operation and Kibana version is lower than 9.3.0
+- **THEN** the system SHALL skip workflow API calls
+- **AND** the system SHALL log that workflows require Kibana 9.3.0+
+
+#### Scenario: Execute workflows on supported Kibana versions
+- **WHEN** the user runs a workflow-related operation and Kibana version is 9.3.0 or newer
+- **THEN** the system SHALL execute workflow API calls against `/api/workflows` endpoints
+- **AND** the system SHALL include `X-Elastic-Internal-Origin: Kibana` on internal API requests
+
+### Requirement: Workflows API Profile Evolution
+The system SHALL support version-aware workflows API request profiles so documented endpoint or payload differences can be applied across versions.
+
+#### Scenario: Select profile by Kibana version
+- **WHEN** the system prepares a workflows API request
+- **THEN** the system SHALL resolve the workflows request profile for the detected Kibana version
+- **AND** request method/path/body SHALL follow that resolved profile

--- a/openspec/changes/kibana-versions/tasks.md
+++ b/openspec/changes/kibana-versions/tasks.md
@@ -1,0 +1,32 @@
+## 1. Kibana Version and Capability Model
+
+- [x] 1.1 Add a normalized Kibana version type and parser in the Kibana client layer.
+- [x] 1.2 Fetch and store Kibana server version during client initialization.
+- [x] 1.3 Define centralized API capability minimum versions (`spaces`, `saved_objects`, `agents`, `tools`, `workflows`).
+- [x] 1.4 Expose helper methods to check API support and return human-readable unsupported reasons.
+
+## 2. Command Flow Gating
+
+- [x] 2.1 Apply capability checks in `pull` orchestration before invoking per-API extractors.
+- [x] 2.2 Apply capability checks in `push` orchestration before invoking per-API loaders.
+- [x] 2.3 Apply capability checks in `add` and dependency-enrichment paths (agents/tools/workflows).
+- [x] 2.4 Apply capability checks in bundle/togo flows and ensure unsupported APIs are skipped.
+- [x] 2.5 Add `--force` flag plumbing to bypass preflight version checks with explicit warning output.
+
+## 3. API Module Integration and Reporting
+
+- [x] 3.1 Ensure agent API calls (`/api/agent_builder/agents`) are only reachable on Kibana 9.2.0+.
+- [x] 3.2 Ensure tools API calls (`/api/agent_builder/tools`) are only reachable on Kibana 9.2.0+.
+- [x] 3.3 Ensure workflows API calls (`/api/workflows`) are only reachable on Kibana 9.3.0+.
+- [x] 3.4 Update logs and command summaries to report skipped APIs with required and detected versions.
+- [x] 3.5 Add and persist `kibana.version` in `spaces.yml` on pull.
+- [x] 3.6 Enforce push compatibility floor from recorded `kibana.version`, with `--force` bypass behavior.
+- [x] 3.7 Update command help/documentation to show per-API minimum versions and tech preview labels.
+
+## 4. Tests and Verification
+
+- [x] 4.1 Add unit tests for version parsing/comparison and capability matrix thresholds.
+- [x] 4.2 Add command-level tests covering boundary versions (8.x, 9.2.x, 9.3.x) with mixed API selections and warning exit semantics.
+- [x] 4.3 Add tests for `--force` behavior across unsupported API checks and push version-floor enforcement.
+- [x] 4.4 Run `cargo clippy` and fix any new warnings introduced by version-gating changes.
+- [x] 4.5 Run `cargo test` and confirm all tests pass.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,7 +1,7 @@
 //! CLI helper functions
 
 use crate::{
-    client::{Auth, KibanaClient},
+    client::{ApiCapability, Auth, KibanaClient, KibanaVersion, KibanaVersionInfo},
     etl::{Extractor, Loader, Transformer},
     kibana::agents::{AgentEntry, AgentsExtractor, AgentsLoader, AgentsManifest},
     kibana::dependencies::{
@@ -17,10 +17,11 @@ use crate::{
         VegaSpecEscaper, VegaSpecUnescaper,
     },
 };
-use eyre::{Context, Result};
+use eyre::{Context, Report, Result};
 use owo_colors::OwoColorize;
 use serde_json::Value;
 use std::collections::HashSet;
+use std::fmt;
 use std::path::Path;
 use std::sync::Arc;
 use tokio::task::JoinSet;
@@ -61,6 +62,135 @@ pub fn load_kibana_client(project_dir: impl AsRef<Path>) -> Result<KibanaClient>
         .context("Failed to create Kibana client")
 }
 
+/// Warning report used to signal a version-gating warning exit (status code 2).
+#[derive(Debug)]
+pub struct VersionWarning {
+    message: String,
+}
+
+impl VersionWarning {
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for VersionWarning {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+impl std::error::Error for VersionWarning {}
+
+fn version_warning(message: impl Into<String>) -> Report {
+    Report::new(VersionWarning::new(message))
+}
+
+/// Return warning text when an error represents a version warning.
+pub fn version_warning_message(report: &Report) -> Option<&str> {
+    report
+        .downcast_ref::<VersionWarning>()
+        .map(|warning| warning.message.as_str())
+}
+
+#[derive(Debug, Clone)]
+struct VersionPreflight {
+    detected: KibanaVersionInfo,
+    recorded: Option<KibanaVersion>,
+}
+
+fn parse_capability(api: &str) -> Option<ApiCapability> {
+    match api {
+        "saved_objects" | "saved_object" | "objects" | "object" => Some(ApiCapability::SavedObjects),
+        "workflows" | "workflow" => Some(ApiCapability::Workflows),
+        "agents" | "agent" => Some(ApiCapability::Agents),
+        "tools" | "tool" => Some(ApiCapability::Tools),
+        "spaces" | "space" => Some(ApiCapability::Spaces),
+        _ => None,
+    }
+}
+
+fn capability_requested(capability: ApiCapability, filter: Option<&[String]>) -> bool {
+    match filter {
+        None => true,
+        Some(values) => values
+            .iter()
+            .filter_map(|v| parse_capability(&v.to_lowercase()))
+            .any(|candidate| candidate == capability),
+    }
+}
+
+fn is_older_major_minor(target: KibanaVersion, recorded: KibanaVersion) -> bool {
+    target.major < recorded.major
+        || (target.major == recorded.major && target.minor < recorded.minor)
+}
+
+fn load_recorded_kibana_version(project_dir: &Path) -> Result<Option<KibanaVersion>> {
+    let spaces_manifest_path = project_dir.join("spaces.yml");
+    if !spaces_manifest_path.exists() {
+        return Ok(None);
+    }
+
+    let manifest = SpacesManifest::read(&spaces_manifest_path)?;
+    match manifest.kibana_version() {
+        Some(version) => match KibanaVersion::parse(version) {
+            Ok(parsed) => Ok(Some(parsed)),
+            Err(e) => {
+                log::warn!(
+                    "Ignoring invalid spaces.yml kibana.version '{}': {}",
+                    version,
+                    e
+                );
+                Ok(None)
+            }
+        },
+        None => Ok(None),
+    }
+}
+
+fn persist_kibana_version(project_dir: &Path, version: &str) -> Result<()> {
+    let spaces_manifest_path = project_dir.join("spaces.yml");
+    let mut manifest = if spaces_manifest_path.exists() {
+        SpacesManifest::read(&spaces_manifest_path)?
+    } else {
+        let mut created = SpacesManifest::new();
+        created.add_space("default".to_string(), "Default".to_string());
+        created
+    };
+
+    manifest.set_kibana_version(version.to_string());
+    manifest.write(&spaces_manifest_path)?;
+    Ok(())
+}
+
+async fn run_version_preflight(
+    project_dir: &Path,
+    client: &KibanaClient,
+    action: &str,
+    force: bool,
+) -> Result<VersionPreflight> {
+    let detected = client.server_version_info().await?;
+    let recorded = load_recorded_kibana_version(project_dir)?;
+
+    if let Some(recorded_version) = recorded
+        && is_older_major_minor(detected.parsed, recorded_version) {
+            let message = format!(
+                "{} requires --force because target Kibana {} is older than recorded repository version {}",
+                action, detected.parsed, recorded_version
+            );
+
+            if force {
+                log::warn!("{}", message);
+            } else {
+                return Err(version_warning(message));
+            }
+        }
+
+    Ok(VersionPreflight { detected, recorded })
+}
+
 /// Check if an API should be processed based on the filter
 fn should_process_api(api_name: &str, filter: Option<&[String]>) -> bool {
     match filter {
@@ -97,15 +227,46 @@ pub async fn pull_saved_objects(
     project_dir: impl AsRef<Path>,
     space_filter: Option<&[String]>,
     api_filter: Option<&[String]>,
+    force: bool,
 ) -> Result<usize> {
     let project_dir = Arc::<Path>::from(project_dir.as_ref());
     let api_filter = api_filter.map(|f| Arc::new(f.to_vec()));
 
     log::info!("Connecting to Kibana...");
     let client = load_kibana_client(&*project_dir)?;
+    let preflight = run_version_preflight(&project_dir, &client, "pull", force).await?;
+    let detected_version = preflight.detected.parsed;
+
+    let mut unsupported = Vec::new();
+    for capability in [
+        ApiCapability::Agents,
+        ApiCapability::Tools,
+        ApiCapability::Workflows,
+    ] {
+        if capability_requested(capability, api_filter.as_deref().map(|f| f.as_slice()))
+            && !KibanaClient::supports_capability(detected_version, capability)
+        {
+            unsupported.push(KibanaClient::unsupported_capability_reason(
+                detected_version,
+                capability,
+            ));
+        }
+    }
+
+    let warning_exit = !force && !unsupported.is_empty();
+    for warning in &unsupported {
+        log::warn!("{}", warning);
+    }
+    if force && !unsupported.is_empty() {
+        log::warn!("--force enabled: attempting API calls despite unsupported version checks");
+    }
 
     // Pull space definitions FIRST (before any other operations)
-    if should_process_api("spaces", api_filter.as_deref().map(|f| f.as_slice())) {
+    let can_pull_spaces = !warning_exit
+        || KibanaClient::supports_capability(detected_version, ApiCapability::Spaces)
+        || force;
+    if can_pull_spaces && should_process_api("spaces", api_filter.as_deref().map(|f| f.as_slice()))
+    {
         let spaces_manifest_path = project_dir.join("spaces.yml");
         if spaces_manifest_path.exists() {
             log::info!("Pulling space definitions...");
@@ -141,6 +302,12 @@ pub async fn pull_saved_objects(
             // Get space client for this space
             let space_client = client.space(&space_id)?;
             let api_filter_slice = api_filter.as_deref().map(|f| f.as_slice());
+            let can_pull_workflows = force
+                || KibanaClient::supports_capability(detected_version, ApiCapability::Workflows);
+            let can_pull_agents = force
+                || KibanaClient::supports_capability(detected_version, ApiCapability::Agents);
+            let can_pull_tools = force
+                || KibanaClient::supports_capability(detected_version, ApiCapability::Tools);
 
             // Pull saved objects for this space
             if should_process_api("saved_objects", api_filter_slice)
@@ -149,19 +316,22 @@ pub async fn pull_saved_objects(
                 }
 
             // Pull workflows for this space
-            if should_process_api("workflows", api_filter_slice)
+            if can_pull_workflows
+                && should_process_api("workflows", api_filter_slice)
                 && let Ok(count) = pull_space_workflows(&project_dir, &space_client).await {
                     log::debug!("Pulled {} workflow(s) for space {}", count, space_id.cyan());
                 }
 
             // Pull agents for this space
-            if should_process_api("agents", api_filter_slice)
+            if can_pull_agents
+                && should_process_api("agents", api_filter_slice)
                 && let Ok(count) = pull_space_agents(&project_dir, &space_client).await {
                     log::debug!("Pulled {} agent(s) for space {}", count, space_id.cyan());
                 }
 
             // Pull tools for this space
-            if should_process_api("tools", api_filter_slice)
+            if can_pull_tools
+                && should_process_api("tools", api_filter_slice)
                 && let Ok(count) = pull_space_tools(&project_dir, &space_client).await {
                     log::debug!("Pulled {} tool(s) for space {}", count, space_id.cyan());
                 }
@@ -182,6 +352,19 @@ pub async fn pull_saved_objects(
         "✓ Pull complete: {} total saved object(s) across all spaces",
         total_count
     );
+
+    // Record the source cluster version after successful pull execution.
+    persist_kibana_version(&project_dir, &preflight.detected.raw)?;
+    if let Some(recorded) = preflight.recorded {
+        log::debug!("Repository kibana.version before pull: {}", recorded);
+    }
+
+    if warning_exit {
+        return Err(version_warning(
+            "One or more requested APIs are unsupported for the target Kibana version".to_string(),
+        ));
+    }
+
     Ok(total_count)
 }
 
@@ -200,12 +383,38 @@ pub async fn push_saved_objects(
     managed: bool,
     space_filter: Option<&[String]>,
     api_filter: Option<&[String]>,
+    force: bool,
 ) -> Result<usize> {
     let project_dir = Arc::<Path>::from(project_dir.as_ref());
     let api_filter = api_filter.map(|f| Arc::new(f.to_vec()));
 
     log::info!("Connecting to Kibana...");
     let client = load_kibana_client(&*project_dir)?;
+    let preflight = run_version_preflight(&project_dir, &client, "push", force).await?;
+    let detected_version = preflight.detected.parsed;
+
+    let mut unsupported = Vec::new();
+    for capability in [
+        ApiCapability::Agents,
+        ApiCapability::Tools,
+        ApiCapability::Workflows,
+    ] {
+        if capability_requested(capability, api_filter.as_deref().map(|f| f.as_slice()))
+            && !KibanaClient::supports_capability(detected_version, capability)
+        {
+            unsupported.push(KibanaClient::unsupported_capability_reason(
+                detected_version,
+                capability,
+            ));
+        }
+    }
+    let warning_exit = !force && !unsupported.is_empty();
+    for warning in &unsupported {
+        log::warn!("{}", warning);
+    }
+    if force && !unsupported.is_empty() {
+        log::warn!("--force enabled: attempting API calls despite unsupported version checks");
+    }
 
     // Push space definitions FIRST (before any other operations)
     if should_process_api("spaces", api_filter.as_deref().map(|f| f.as_slice())) {
@@ -251,6 +460,12 @@ pub async fn push_saved_objects(
             // Get space client for this space
             let space_client = client.space(&space_id)?;
             let api_filter_slice = api_filter.as_deref().map(|f| f.as_slice());
+            let can_push_workflows = force
+                || KibanaClient::supports_capability(detected_version, ApiCapability::Workflows);
+            let can_push_agents = force
+                || KibanaClient::supports_capability(detected_version, ApiCapability::Agents);
+            let can_push_tools = force
+                || KibanaClient::supports_capability(detected_version, ApiCapability::Tools);
 
             // Push saved objects for this space
             if should_process_api("saved_objects", api_filter_slice) {
@@ -269,7 +484,7 @@ pub async fn push_saved_objects(
             }
 
             // Push workflows for this space
-            if should_process_api("workflows", api_filter_slice) {
+            if can_push_workflows && should_process_api("workflows", api_filter_slice) {
                 match push_space_workflows(&project_dir, &space_client).await {
                     Ok(count) => {
                         s_wf = count;
@@ -285,7 +500,7 @@ pub async fn push_saved_objects(
             }
 
             // Push tools for this space
-            if should_process_api("tools", api_filter_slice) {
+            if can_push_tools && should_process_api("tools", api_filter_slice) {
                 match push_space_tools(&project_dir, &space_client).await {
                     Ok(count) => {
                         s_tl = count;
@@ -297,7 +512,7 @@ pub async fn push_saved_objects(
             }
 
             // Push agents for this space
-            if should_process_api("agents", api_filter_slice) {
+            if can_push_agents && should_process_api("agents", api_filter_slice) {
                 match push_space_agents(&project_dir, &space_client).await {
                     Ok(count) => {
                         s_ag = count;
@@ -332,6 +547,13 @@ pub async fn push_saved_objects(
         total_agents,
         total_tools
     );
+
+    if warning_exit {
+        return Err(version_warning(
+            "One or more requested APIs are unsupported for the target Kibana version".to_string(),
+        ));
+    }
+
     Ok(total_saved_objects + total_workflows + total_agents + total_tools)
 }
 
@@ -354,10 +576,42 @@ pub async fn bundle_to_ndjson(
     api_filter: Option<&[String]>,
 ) -> Result<usize> {
     let project_dir = project_dir.as_ref();
+    let recorded_version = load_recorded_kibana_version(project_dir)?;
     // Determine which spaces to operate on (reads from spaces.yml directly)
     let target_space_ids = get_target_space_ids_from_manifest(project_dir, space_filter);
 
     let mut total_count = 0;
+
+    let can_bundle_workflows = recorded_version
+        .map(|v| KibanaClient::supports_capability(v, ApiCapability::Workflows))
+        .unwrap_or(true);
+    let can_bundle_agents = recorded_version
+        .map(|v| KibanaClient::supports_capability(v, ApiCapability::Agents))
+        .unwrap_or(true);
+    let can_bundle_tools = recorded_version
+        .map(|v| KibanaClient::supports_capability(v, ApiCapability::Tools))
+        .unwrap_or(true);
+
+    if let Some(version) = recorded_version {
+        if capability_requested(ApiCapability::Workflows, api_filter) && !can_bundle_workflows {
+            log::warn!(
+                "{}",
+                KibanaClient::unsupported_capability_reason(version, ApiCapability::Workflows)
+            );
+        }
+        if capability_requested(ApiCapability::Agents, api_filter) && !can_bundle_agents {
+            log::warn!(
+                "{}",
+                KibanaClient::unsupported_capability_reason(version, ApiCapability::Agents)
+            );
+        }
+        if capability_requested(ApiCapability::Tools, api_filter) && !can_bundle_tools {
+            log::warn!(
+                "{}",
+                KibanaClient::unsupported_capability_reason(version, ApiCapability::Tools)
+            );
+        }
+    }
 
     // Bundle each managed space
     for space_id in &target_space_ids {
@@ -370,7 +624,8 @@ pub async fn bundle_to_ndjson(
             }
 
         // Bundle workflows for this space
-        if should_process_api("workflows", api_filter)
+        if can_bundle_workflows
+            && should_process_api("workflows", api_filter)
             && let Ok(count) = bundle_space_workflows(project_dir, space_id).await {
                 log::debug!(
                     "Bundled {} workflow(s) for space {}",
@@ -380,13 +635,15 @@ pub async fn bundle_to_ndjson(
             }
 
         // Bundle tools for this space
-        if should_process_api("tools", api_filter)
+        if can_bundle_tools
+            && should_process_api("tools", api_filter)
             && let Ok(count) = bundle_space_tools(project_dir, space_id).await {
                 log::debug!("Bundled {} tool(s) for space {}", count, space_id.cyan());
             }
 
         // Bundle agents for this space
-        if should_process_api("agents", api_filter)
+        if can_bundle_agents
+            && should_process_api("agents", api_filter)
             && let Ok(count) = bundle_space_agents(project_dir, space_id).await {
                 log::debug!("Bundled {} agent(s) for space {}", count, space_id.cyan());
             }
@@ -504,6 +761,7 @@ pub async fn add_objects_to_manifest(
     space_id: &str,
     objects_to_add: Option<Vec<String>>,
     file_path: Option<impl AsRef<Path>>,
+    force: bool,
 ) -> Result<usize> {
     use crate::kibana::saved_objects::{SavedObject, SavedObjectsExtractor, SavedObjectsManifest};
 
@@ -560,6 +818,7 @@ pub async fn add_objects_to_manifest(
         // Fetch from Kibana
         log::info!("Fetching {} object(s) from Kibana", object_specs.len());
         let client = load_kibana_client(project_dir)?;
+        let _preflight = run_version_preflight(project_dir, &client, "add", force).await?;
         let space_client = client.space(space_id)?;
 
         // Parse object specs (format: "type=id" or "type:id")
@@ -626,6 +885,7 @@ pub async fn add_objects_to_manifest(
 ///
 /// Can add from Kibana search API or from a file (.json or .ndjson)
 /// Optionally filter results by name using regex patterns (--include, --exclude)
+#[allow(clippy::too_many_arguments)]
 pub async fn add_workflows_to_manifest(
     project_dir: impl AsRef<Path>,
     space_id: &str,
@@ -634,6 +894,7 @@ pub async fn add_workflows_to_manifest(
     exclude: Option<String>,
     file_path: Option<String>,
     exclude_dependencies: bool,
+    force: bool,
 ) -> Result<usize> {
     use crate::kibana::workflows::WorkflowEntry;
 
@@ -666,6 +927,30 @@ pub async fn add_workflows_to_manifest(
         WorkflowsManifest::new()
     };
     log::info!("Current manifest has {} workflow(s)", manifest.count());
+
+    let requires_kibana_calls = file_path.is_none() || !exclude_dependencies;
+    let mut preflight_client: Option<KibanaClient> = None;
+    let mut detected_version: Option<KibanaVersion> = None;
+    if requires_kibana_calls {
+        let client = load_kibana_client(project_dir)?;
+        let preflight = run_version_preflight(project_dir, &client, "add", force).await?;
+        detected_version = Some(preflight.detected.parsed);
+        preflight_client = Some(client);
+    }
+
+    if let Some(version) = detected_version
+        && !KibanaClient::supports_capability(version, ApiCapability::Workflows)
+    {
+        let reason = KibanaClient::unsupported_capability_reason(version, ApiCapability::Workflows);
+        if force {
+            log::warn!("{}", reason);
+            log::warn!("--force enabled: attempting workflows API calls anyway");
+        } else if file_path.is_none() {
+            return Err(version_warning(reason));
+        } else {
+            log::warn!("{}", reason);
+        }
+    }
 
     // Fetch workflows from API or file
     let new_workflows: Vec<serde_json::Value> = if let Some(file) = file_path {
@@ -731,7 +1016,9 @@ pub async fn add_workflows_to_manifest(
             "Searching workflows via API in space {}...",
             space_id.cyan()
         );
-        let client = load_kibana_client(project_dir)?;
+        let client = preflight_client
+            .clone()
+            .unwrap_or(load_kibana_client(project_dir)?);
         let space_client = client.space(space_id)?;
         let extractor = WorkflowsExtractor::new(space_client, None);
 
@@ -835,9 +1122,9 @@ pub async fn add_workflows_to_manifest(
     // Resolve dependencies if any
     let mut dep_summary = DependencySummary::new();
     if !all_deps.is_empty() {
-        let client = load_kibana_client(project_dir)?;
-        dep_summary =
-            resolve_and_add_dependencies(project_dir, space_id, &client, all_deps).await?;
+        let client = preflight_client.unwrap_or(load_kibana_client(project_dir)?);
+        let version = client.server_version().await?;
+        dep_summary = resolve_and_add_dependencies(project_dir, space_id, &client, all_deps, version, force).await?;
     }
 
     // Create manifest directory if it doesn't exist
@@ -877,6 +1164,7 @@ pub async fn add_spaces_to_manifest(
     include: Option<String>,
     exclude: Option<String>,
     file_path: Option<String>,
+    force: bool,
 ) -> Result<usize> {
     let project_dir = project_dir.as_ref();
 
@@ -952,6 +1240,7 @@ pub async fn add_spaces_to_manifest(
         }
         log::info!("Fetching spaces via API...");
         let client = load_kibana_client(project_dir)?;
+        let _preflight = run_version_preflight(project_dir, &client, "add", force).await?;
         let extractor = SpacesExtractor::new(client, None);
 
         extractor.search_spaces(query.as_deref()).await?
@@ -1583,6 +1872,7 @@ fn load_agents_manifest(project_dir: impl AsRef<Path>) -> Result<AgentsManifest>
 ///
 /// Can add from Kibana search API or from a file (.json or .ndjson)
 /// Optionally filter results by name using regex patterns (--include, --exclude)
+#[allow(clippy::too_many_arguments)]
 pub async fn add_agents_to_manifest(
     project_dir: impl AsRef<Path>,
     space_id: &str,
@@ -1591,6 +1881,7 @@ pub async fn add_agents_to_manifest(
     exclude: Option<String>,
     file_path: Option<String>,
     exclude_dependencies: bool,
+    force: bool,
 ) -> Result<usize> {
     use crate::kibana::agents::AgentEntry;
 
@@ -1623,6 +1914,30 @@ pub async fn add_agents_to_manifest(
         AgentsManifest::new()
     };
     log::info!("Current manifest has {} agent(s)", manifest.count());
+
+    let requires_kibana_calls = file_path.is_none() || !exclude_dependencies;
+    let mut preflight_client: Option<KibanaClient> = None;
+    let mut detected_version: Option<KibanaVersion> = None;
+    if requires_kibana_calls {
+        let client = load_kibana_client(project_dir)?;
+        let preflight = run_version_preflight(project_dir, &client, "add", force).await?;
+        detected_version = Some(preflight.detected.parsed);
+        preflight_client = Some(client);
+    }
+
+    if let Some(version) = detected_version
+        && !KibanaClient::supports_capability(version, ApiCapability::Agents)
+    {
+        let reason = KibanaClient::unsupported_capability_reason(version, ApiCapability::Agents);
+        if force {
+            log::warn!("{}", reason);
+            log::warn!("--force enabled: attempting agents API calls anyway");
+        } else if file_path.is_none() {
+            return Err(version_warning(reason));
+        } else {
+            log::warn!("{}", reason);
+        }
+    }
 
     // Fetch agents from API or file
     let new_agents: Vec<serde_json::Value> = if let Some(file) = file_path {
@@ -1681,7 +1996,9 @@ pub async fn add_agents_to_manifest(
     } else {
         // Search via API
         log::info!("Searching agents via API in space {}...", space_id.cyan());
-        let client = load_kibana_client(project_dir)?;
+        let client = preflight_client
+            .clone()
+            .unwrap_or(load_kibana_client(project_dir)?);
         let space_client = client.space(space_id)?;
         let extractor = AgentsExtractor::new(space_client, None);
 
@@ -1778,9 +2095,9 @@ pub async fn add_agents_to_manifest(
     // Resolve dependencies if any
     let mut dep_summary = DependencySummary::new();
     if !all_deps.is_empty() {
-        let client = load_kibana_client(project_dir)?;
-        dep_summary =
-            resolve_and_add_dependencies(project_dir, space_id, &client, all_deps).await?;
+        let client = preflight_client.unwrap_or(load_kibana_client(project_dir)?);
+        let version = client.server_version().await?;
+        dep_summary = resolve_and_add_dependencies(project_dir, space_id, &client, all_deps, version, force).await?;
     }
 
     // Create manifest directory if it doesn't exist
@@ -1975,6 +2292,7 @@ fn load_tools_manifest(project_dir: impl AsRef<Path>) -> Result<ToolsManifest> {
 ///
 /// Can add from Kibana search API or from a file (.json or .ndjson)
 /// Optionally filter results by name using regex patterns (--include, --exclude)
+#[allow(clippy::too_many_arguments)]
 pub async fn add_tools_to_manifest(
     project_dir: impl AsRef<Path>,
     space_id: &str,
@@ -1983,6 +2301,7 @@ pub async fn add_tools_to_manifest(
     exclude: Option<String>,
     file_path: Option<String>,
     exclude_dependencies: bool,
+    force: bool,
 ) -> Result<usize> {
     let project_dir = project_dir.as_ref();
 
@@ -2014,6 +2333,30 @@ pub async fn add_tools_to_manifest(
         ToolsManifest::new()
     };
     log::info!("Current manifest has {} tool(s)", manifest.count());
+
+    let requires_kibana_calls = file_path.is_none() || !exclude_dependencies;
+    let mut preflight_client: Option<KibanaClient> = None;
+    let mut detected_version: Option<KibanaVersion> = None;
+    if requires_kibana_calls {
+        let client = load_kibana_client(project_dir)?;
+        let preflight = run_version_preflight(project_dir, &client, "add", force).await?;
+        detected_version = Some(preflight.detected.parsed);
+        preflight_client = Some(client);
+    }
+
+    if let Some(version) = detected_version
+        && !KibanaClient::supports_capability(version, ApiCapability::Tools)
+    {
+        let reason = KibanaClient::unsupported_capability_reason(version, ApiCapability::Tools);
+        if force {
+            log::warn!("{}", reason);
+            log::warn!("--force enabled: attempting tools API calls anyway");
+        } else if file_path.is_none() {
+            return Err(version_warning(reason));
+        } else {
+            log::warn!("{}", reason);
+        }
+    }
 
     // Fetch tools from API or file
     let new_tools: Vec<serde_json::Value> = if let Some(file) = file_path {
@@ -2072,7 +2415,9 @@ pub async fn add_tools_to_manifest(
     } else {
         // Search via API
         log::info!("Searching tools via API in space {}...", space_id.cyan());
-        let client = load_kibana_client(project_dir)?;
+        let client = preflight_client
+            .clone()
+            .unwrap_or(load_kibana_client(project_dir)?);
         let space_client = client.space(space_id)?;
         let extractor = ToolsExtractor::new(space_client, None);
 
@@ -2174,9 +2519,9 @@ pub async fn add_tools_to_manifest(
     // Resolve dependencies if any
     let mut dep_summary = DependencySummary::new();
     if !all_deps.is_empty() {
-        let client = load_kibana_client(project_dir)?;
-        dep_summary =
-            resolve_and_add_dependencies(project_dir, space_id, &client, all_deps).await?;
+        let client = preflight_client.unwrap_or(load_kibana_client(project_dir)?);
+        let version = client.server_version().await?;
+        dep_summary = resolve_and_add_dependencies(project_dir, space_id, &client, all_deps, version, force).await?;
     }
 
     // Create manifest directory if it doesn't exist
@@ -3025,6 +3370,8 @@ async fn resolve_and_add_dependencies(
     space_id: &str,
     client: &KibanaClient,
     initial_deps: Vec<Dependency>,
+    detected_version: KibanaVersion,
+    force: bool,
 ) -> Result<DependencySummary> {
     let client = client.space(space_id)?;
     let mut pending_deps = initial_deps;
@@ -3034,6 +3381,18 @@ async fn resolve_and_add_dependencies(
     while let Some(dep) = pending_deps.pop() {
         match dep {
             Dependency::Agent(id) => {
+                if !force
+                    && !KibanaClient::supports_capability(detected_version, ApiCapability::Agents)
+                {
+                    log::warn!(
+                        "{}",
+                        KibanaClient::unsupported_capability_reason(
+                            detected_version,
+                            ApiCapability::Agents
+                        )
+                    );
+                    continue;
+                }
                 if !processed_ids.insert(format!("agent:{}", id)) {
                     continue;
                 }
@@ -3076,6 +3435,18 @@ async fn resolve_and_add_dependencies(
                 }
             }
             Dependency::Tool(id) => {
+                if !force
+                    && !KibanaClient::supports_capability(detected_version, ApiCapability::Tools)
+                {
+                    log::warn!(
+                        "{}",
+                        KibanaClient::unsupported_capability_reason(
+                            detected_version,
+                            ApiCapability::Tools
+                        )
+                    );
+                    continue;
+                }
                 if !processed_ids.insert(format!("tool:{}", id)) {
                     continue;
                 }
@@ -3118,6 +3489,21 @@ async fn resolve_and_add_dependencies(
                 }
             }
             Dependency::Workflow(id) => {
+                if !force
+                    && !KibanaClient::supports_capability(
+                        detected_version,
+                        ApiCapability::Workflows,
+                    )
+                {
+                    log::warn!(
+                        "{}",
+                        KibanaClient::unsupported_capability_reason(
+                            detected_version,
+                            ApiCapability::Workflows
+                        )
+                    );
+                    continue;
+                }
                 if !processed_ids.insert(format!("workflow:{}", id)) {
                     continue;
                 }
@@ -3309,5 +3695,28 @@ mod tests {
             "1 agent(s), 2 tool(s), 3 workflow(s)"
         );
         assert_eq!(summary.total(), 6);
+    }
+
+    #[test]
+    fn test_is_older_major_minor() {
+        let recorded = KibanaVersion::parse("9.3.2").unwrap();
+        assert!(is_older_major_minor(
+            KibanaVersion::parse("9.2.9").unwrap(),
+            recorded
+        ));
+        assert!(!is_older_major_minor(
+            KibanaVersion::parse("9.3.0").unwrap(),
+            recorded
+        ));
+        assert!(!is_older_major_minor(
+            KibanaVersion::parse("10.0.0").unwrap(),
+            recorded
+        ));
+    }
+
+    #[test]
+    fn test_version_warning_downcast() {
+        let report = version_warning("test warning");
+        assert_eq!(version_warning_message(&report), Some("test warning"));
     }
 }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -7,4 +7,6 @@ mod auth;
 mod kibana;
 
 pub use auth::{Auth, AuthType};
-pub use kibana::{ApiCapability, KibanaClient, KibanaVersion, KibanaVersionInfo};
+pub use kibana::{
+    ApiCapability, KibanaClient, KibanaVersion, KibanaVersionInfo, parse_kibana_version,
+};

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -7,4 +7,4 @@ mod auth;
 mod kibana;
 
 pub use auth::{Auth, AuthType};
-pub use kibana::KibanaClient;
+pub use kibana::{ApiCapability, KibanaClient, KibanaVersion, KibanaVersionInfo};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@ pub mod storage;
 pub mod transform;
 
 // Re-exports for convenience
-pub use client::{Auth, AuthType, KibanaClient};
+pub use client::{ApiCapability, Auth, AuthType, KibanaClient, KibanaVersion, KibanaVersionInfo};
 pub use etl::{Extractor, IdentityTransformer, Loader, Pipeline, Transformer};
 pub use storage::{
     DirectoryReader, DirectoryWriter, GitIgnoreManager, ManifestDirectory, NdjsonReader,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,10 @@ pub mod storage;
 pub mod transform;
 
 // Re-exports for convenience
-pub use client::{ApiCapability, Auth, AuthType, KibanaClient, KibanaVersion, KibanaVersionInfo};
+pub use client::{
+    ApiCapability, Auth, AuthType, KibanaClient, KibanaVersion, KibanaVersionInfo,
+    parse_kibana_version,
+};
 pub use etl::{Extractor, IdentityTransformer, Loader, Pipeline, Transformer};
 pub use storage::{
     DirectoryReader, DirectoryWriter, GitIgnoreManager, ManifestDirectory, NdjsonReader,


### PR DESCRIPTION
## Summary
- add Kibana version preflight via `/api/status` and capability gating for agents/tools/workflows
- persist kibana.version in spaces.yml after pull and enforce push/add/pull version floor checks
- add `--force` for version-gated commands, with warning behavior and exit code 2 for version warnings
- document API minimum versions in CLI help text
- bump crate version to 0.2.0