### PR TITLE
feat(kibana-sync): support embedded bundle entries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,7 +717,7 @@ dependencies = [
 
 [[package]]
 name = "kibana-sync"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "base64",
  "json5",

--- a/crates/kibana-object-manager/Cargo.toml
+++ b/crates/kibana-object-manager/Cargo.toml
@@ -30,7 +30,7 @@ path = "src/main.rs"
 clap = { version = "^4.5", features = ["derive"] }
 dotenvy = "^0.15"
 eyre = "^0.6"
-kibana-sync = { version = "0.2.2", path = "../kibana-sync" }
+kibana-sync = { version = "0.2.3", path = "../kibana-sync" }
 log = "^0.4"
 owo-colors = "4.2.0"
 regex = "^1.12"

--- a/crates/kibana-object-manager/tests/live_kibana_integration.rs
+++ b/crates/kibana-object-manager/tests/live_kibana_integration.rs
@@ -237,10 +237,8 @@ async fn live_skills_threat_hunting_referenced_content_roundtrip() -> Result<()>
     }
     .await;
 
-    if created {
-        if let Err(err) = loader.delete_skill(&test_skill_id, true).await {
-            eprintln!("Best-effort cleanup failed for skill {test_skill_id}: {err}");
-        }
+    if created && let Err(err) = loader.delete_skill(&test_skill_id, true).await {
+        eprintln!("Best-effort cleanup failed for skill {test_skill_id}: {err}");
     }
 
     result?;
@@ -268,7 +266,7 @@ fn normalized_referenced_content(skill: &serde_json::Value) -> Vec<serde_json::V
         })
         .unwrap_or_default();
 
-    referenced.sort_by(|left, right| left.to_string().cmp(&right.to_string()));
+    referenced.sort_by_key(|left| left.to_string());
     referenced
 }
 

--- a/crates/kibana-object-manager/tests/live_kibana_integration.rs
+++ b/crates/kibana-object-manager/tests/live_kibana_integration.rs
@@ -266,7 +266,7 @@ fn normalized_referenced_content(skill: &serde_json::Value) -> Vec<serde_json::V
         })
         .unwrap_or_default();
 
-    referenced.sort_by_key(|left| left.to_string());
+    referenced.sort_by_cached_key(|left| left.to_string());
     referenced
 }
 

--- a/crates/kibana-sync/Cargo.toml
+++ b/crates/kibana-sync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kibana-sync"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2024"
 rust-version = "1.89"
 authors = ["Ryan Eno"]

--- a/crates/kibana-sync/README.md
+++ b/crates/kibana-sync/README.md
@@ -45,7 +45,7 @@ use kibana_sync::{Entries, KibanaBundle};
 let bundle: KibanaBundle<Entries<&'static [u8]>> = KibanaBundle::from_entries([
     (
         "spaces.yml",
-        include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/README.md")).as_slice(),
+        b"spaces:\n  - id: default\n    name: Default\n".as_slice(),
     ),
 ])?;
 let resources = bundle.read_all()?;

--- a/crates/kibana-sync/README.md
+++ b/crates/kibana-sync/README.md
@@ -19,3 +19,40 @@ let version = default_space.server_version().await?;
 # Ok(())
 # }
 ```
+
+## Bundle sources
+
+Use `KibanaBundle<Filesystem>` for the stable on-disk bundle layout:
+
+```rust,no_run
+use kibana_sync::{Filesystem, KibanaBundle};
+
+# fn run() -> kibana_sync::Result<()> {
+let bundle: KibanaBundle<Filesystem> = KibanaBundle::open("./kibana-bundle")?;
+let resources = bundle.read_all()?;
+# let _ = resources;
+# Ok(())
+# }
+```
+
+Embedded or in-memory consumers can provide root-relative paths and any uniform
+content type implementing `AsRef<[u8]>`:
+
+```rust,no_run
+use kibana_sync::{Entries, KibanaBundle};
+
+# fn run() -> kibana_sync::Result<()> {
+let bundle: KibanaBundle<Entries<&'static [u8]>> = KibanaBundle::from_entries([
+    (
+        "spaces.yml",
+        include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/README.md")).as_slice(),
+    ),
+])?;
+let resources = bundle.read_all()?;
+# let _ = resources;
+# Ok(())
+# }
+```
+
+The same constructor accepts dynamically collected `(path, Vec<u8>)` entries
+without changing bundle parsing or materializing temporary files.

--- a/crates/kibana-sync/src/bundle.rs
+++ b/crates/kibana-sync/src/bundle.rs
@@ -536,15 +536,24 @@ impl BundleSource for Filesystem {
     type Content<'a> = Vec<u8>;
 
     fn is_file(&self, path: &Path) -> bool {
-        self.root.join(path).is_file()
+        std::fs::symlink_metadata(self.root.join(path))
+            .map(|metadata| metadata.is_file())
+            .unwrap_or(false)
     }
 
     fn is_dir(&self, path: &Path) -> bool {
-        self.root.join(path).is_dir()
+        std::fs::symlink_metadata(self.root.join(path))
+            .map(|metadata| metadata.is_dir())
+            .unwrap_or(false)
     }
 
     fn read(&self, path: &Path) -> Result<Self::Content<'_>> {
-        std::fs::read(self.root.join(path)).map_err(Into::into)
+        let path = self.root.join(path);
+        let metadata = std::fs::symlink_metadata(&path)?;
+        if metadata.file_type().is_symlink() {
+            return Err(bundle_symlink_error(&path));
+        }
+        std::fs::read(path).map_err(Into::into)
     }
 
     fn files_under(&self, path: &Path) -> Result<Vec<PathBuf>> {

--- a/crates/kibana-sync/src/bundle.rs
+++ b/crates/kibana-sync/src/bundle.rs
@@ -76,6 +76,9 @@ impl KibanaBundle<Filesystem> {
                 root.display()
             )));
         }
+        if std::fs::symlink_metadata(&root)?.file_type().is_symlink() {
+            return Err(bundle_symlink_error(&root));
+        }
         Ok(Self {
             source: Filesystem { root },
         })
@@ -86,6 +89,9 @@ impl KibanaBundle<Filesystem> {
         let root = root.as_ref().to_path_buf();
         std::fs::create_dir_all(&root)
             .with_context(|| format!("Failed to create bundle root: {}", root.display()))?;
+        if std::fs::symlink_metadata(&root)?.file_type().is_symlink() {
+            return Err(bundle_symlink_error(&root));
+        }
         Ok(Self {
             source: Filesystem { root },
         })
@@ -1069,6 +1075,24 @@ mod tests {
                 .to_string()
                 .contains("bundle paths cannot be symlinks")
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn filesystem_bundle_roots_cannot_be_symlinks() {
+        let temp = TempDir::new().unwrap();
+        let outside = TempDir::new().unwrap();
+        let root = temp.path().join("bundle");
+        std::os::unix::fs::symlink(outside.path(), &root).unwrap();
+
+        for result in [KibanaBundle::open(&root), KibanaBundle::create(&root)] {
+            let error = result.unwrap_err();
+            assert!(
+                error
+                    .to_string()
+                    .contains("bundle paths cannot be symlinks")
+            );
+        }
     }
 
     #[test]

--- a/crates/kibana-sync/src/bundle.rs
+++ b/crates/kibana-sync/src/bundle.rs
@@ -472,7 +472,12 @@ impl<S: BundleSource> KibanaBundle<S> {
             )
         })?;
         let text = utf8(content.as_ref(), &self.source.display_path(path))?;
-        yaml_serde::from_str(text).with_context(|| format!("Failed to parse {kind} manifest YAML"))
+        yaml_serde::from_str(text).with_context(|| {
+            format!(
+                "Failed to parse {kind} manifest YAML: {}",
+                self.source.display_path(path)
+            )
+        })
     }
 
     fn read_json_manifest<T: DeserializeOwned>(&self, path: &Path, kind: &str) -> Result<T> {
@@ -483,7 +488,12 @@ impl<S: BundleSource> KibanaBundle<S> {
             )
         })?;
         let text = utf8(content.as_ref(), &self.source.display_path(path))?;
-        serde_json::from_str(text).with_context(|| format!("Failed to parse {kind} manifest JSON"))
+        serde_json::from_str(text).with_context(|| {
+            format!(
+                "Failed to parse {kind} manifest JSON: {}",
+                self.source.display_path(path)
+            )
+        })
     }
 
     fn missing_manifest_resource(
@@ -540,7 +550,12 @@ impl BundleSource for Filesystem {
         let mut directories = Vec::new();
         for entry in std::fs::read_dir(directory)? {
             let entry = entry?;
-            if entry.path().is_dir() {
+            let entry_path = entry.path();
+            let metadata = std::fs::symlink_metadata(&entry_path)?;
+            if metadata.file_type().is_symlink() {
+                return Err(bundle_symlink_error(&entry_path));
+            }
+            if metadata.is_dir() {
                 directories.push(path.join(entry.file_name()));
             }
         }
@@ -650,14 +665,26 @@ fn normalize_entry_path(path: &Path) -> Result<PathBuf> {
 }
 
 fn collect_files(root: &Path, directory: &Path, files: &mut Vec<PathBuf>) -> Result<()> {
-    if !directory.is_dir() {
+    let metadata = match std::fs::symlink_metadata(directory) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error.into()),
+    };
+    if metadata.file_type().is_symlink() {
+        return Err(bundle_symlink_error(directory));
+    }
+    if !metadata.is_dir() {
         return Ok(());
     }
     for entry in std::fs::read_dir(directory)? {
         let path = entry?.path();
-        if path.is_dir() {
+        let metadata = std::fs::symlink_metadata(&path)?;
+        if metadata.file_type().is_symlink() {
+            return Err(bundle_symlink_error(&path));
+        }
+        if metadata.is_dir() {
             collect_files(root, &path, files)?;
-        } else if path.is_file() {
+        } else if metadata.is_file() {
             files.push(
                 path.strip_prefix(root)
                     .map_err(|_| {
@@ -668,6 +695,13 @@ fn collect_files(root: &Path, directory: &Path, files: &mut Vec<PathBuf>) -> Res
         }
     }
     Ok(())
+}
+
+fn bundle_symlink_error(path: &Path) -> Error {
+    Error::message(format!(
+        "bundle paths cannot be symlinks: {}",
+        path.display()
+    ))
 }
 
 fn validate_filesystem_tree(canonical_root: &Path, directory: &Path) -> Result<()> {
@@ -931,6 +965,45 @@ mod tests {
             invalid_json
                 .to_string()
                 .contains("default/objects/bad.json")
+        );
+    }
+
+    #[test]
+    fn manifest_parse_errors_include_logical_paths() {
+        let yaml_error = KibanaBundle::from_entries([("spaces.yml", b"{".as_slice())])
+            .unwrap()
+            .read_all()
+            .unwrap_err();
+        assert!(yaml_error.to_string().contains("spaces.yml"));
+
+        let json_error =
+            KibanaBundle::from_entries([("default/manifest/saved_objects.json", b"{".as_slice())])
+                .unwrap()
+                .read_all()
+                .unwrap_err();
+        assert!(
+            json_error
+                .to_string()
+                .contains("default/manifest/saved_objects.json")
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn filesystem_sources_reject_symlink_traversal() {
+        let temp = TempDir::new().unwrap();
+        let outside = TempDir::new().unwrap();
+        std::os::unix::fs::symlink(outside.path(), temp.path().join("default")).unwrap();
+
+        let error = KibanaBundle::open(temp.path())
+            .unwrap()
+            .read_all()
+            .unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("bundle paths cannot be symlinks")
         );
     }
 

--- a/crates/kibana-sync/src/bundle.rs
+++ b/crates/kibana-sync/src/bundle.rs
@@ -528,6 +528,7 @@ impl BundleSource for Filesystem {
     fn files_under(&self, path: &Path) -> Result<Vec<PathBuf>> {
         let mut files = Vec::new();
         collect_files(&self.root, &self.root.join(path), &mut files)?;
+        files.sort();
         Ok(files)
     }
 
@@ -606,7 +607,7 @@ impl<B: AsRef<[u8]>> BundleSource for Entries<B> {
     }
 
     fn display_path(&self, path: &Path) -> String {
-        path.display().to_string()
+        path.to_string_lossy().replace('\\', "/")
     }
 }
 
@@ -666,7 +667,6 @@ fn collect_files(root: &Path, directory: &Path, files: &mut Vec<PathBuf>) -> Res
             );
         }
     }
-    files.sort();
     Ok(())
 }
 
@@ -1048,5 +1048,23 @@ mod tests {
 
         assert_eq!(actual, expected);
         assert_eq!(filesystem.root(), temp.path());
+    }
+
+    #[test]
+    fn filesystem_write_defaults_space_definition_name() {
+        let temp = TempDir::new().unwrap();
+        let filesystem = KibanaBundle::create(temp.path()).unwrap();
+        let bundle = SyncBundle {
+            spaces: vec![json!({"id": "default"})],
+            ..SyncBundle::default()
+        };
+
+        filesystem.write(&bundle).unwrap();
+        let read = KibanaBundle::open(temp.path()).unwrap().read_all().unwrap();
+
+        assert_eq!(
+            read.spaces,
+            vec![json!({"id": "default", "name": "default"})]
+        );
     }
 }

--- a/crates/kibana-sync/src/bundle.rs
+++ b/crates/kibana-sync/src/bundle.rs
@@ -537,13 +537,13 @@ impl BundleSource for Filesystem {
 
     fn is_file(&self, path: &Path) -> bool {
         std::fs::symlink_metadata(self.root.join(path))
-            .map(|metadata| metadata.is_file())
+            .map(|metadata| metadata.is_file() || metadata.file_type().is_symlink())
             .unwrap_or(false)
     }
 
     fn is_dir(&self, path: &Path) -> bool {
         std::fs::symlink_metadata(self.root.join(path))
-            .map(|metadata| metadata.is_dir())
+            .map(|metadata| metadata.is_dir() || metadata.file_type().is_symlink())
             .unwrap_or(false)
     }
 
@@ -630,8 +630,9 @@ impl<B: AsRef<[u8]>> BundleSource for Entries<B> {
     fn files_under(&self, path: &Path) -> Result<Vec<PathBuf>> {
         Ok(self
             .files
-            .keys()
-            .filter(|entry| entry.starts_with(path))
+            .range(path.to_path_buf()..)
+            .take_while(|(entry, _)| entry.starts_with(path))
+            .map(|(entry, _)| entry)
             .cloned()
             .collect())
     }

--- a/crates/kibana-sync/src/bundle.rs
+++ b/crates/kibana-sync/src/bundle.rs
@@ -164,7 +164,7 @@ impl<S: BundleSource> KibanaBundle<S> {
         let selection = SyncSelection {
             spaces,
             saved_objects: Some(SavedObjectsManifest::new()),
-            include_spaces: self.source.is_file(Path::new("spaces.yml")),
+            include_spaces: self.manifest_is_file(Path::new("spaces.yml"))?,
             include_workflows: true,
             include_agents: true,
             include_tools: true,
@@ -212,7 +212,7 @@ impl<S: BundleSource> KibanaBundle<S> {
         let directory = resource_dir(space_id, "objects");
         let values = self.read_json_dir(&directory)?;
         let manifest_path = manifest_path(space_id, "saved_objects.json");
-        let manifest = if self.source.is_file(&manifest_path) {
+        let manifest = if self.manifest_is_file(&manifest_path)? {
             Some(self.read_json_manifest(&manifest_path, "saved objects")?)
         } else if selection_manifest.objects.is_empty() {
             None
@@ -246,7 +246,7 @@ impl<S: BundleSource> KibanaBundle<S> {
         let directory = resource_dir(space_id, "workflows");
         let values = self.read_json_dir(&directory)?;
         let manifest_path = manifest_path(space_id, "workflows.yml");
-        if !self.source.is_file(&manifest_path) {
+        if !self.manifest_is_file(&manifest_path)? {
             return Ok(values);
         }
         let manifest: WorkflowsManifest = self.read_yaml_manifest(&manifest_path, "workflows")?;
@@ -265,7 +265,7 @@ impl<S: BundleSource> KibanaBundle<S> {
         let directory = resource_dir(space_id, "agents");
         let values = self.read_json_dir(&directory)?;
         let manifest_path = manifest_path(space_id, "agents.yml");
-        if !self.source.is_file(&manifest_path) {
+        if !self.manifest_is_file(&manifest_path)? {
             return Ok(values);
         }
         let manifest: AgentsManifest = self.read_yaml_manifest(&manifest_path, "agents")?;
@@ -283,7 +283,7 @@ impl<S: BundleSource> KibanaBundle<S> {
         let directory = resource_dir(space_id, "tools");
         let values = self.read_json_dir(&directory)?;
         let manifest_path = manifest_path(space_id, "tools.yml");
-        if !self.source.is_file(&manifest_path) {
+        if !self.manifest_is_file(&manifest_path)? {
             return Ok(values);
         }
         let manifest: ToolsManifest = self.read_yaml_manifest(&manifest_path, "tools")?;
@@ -300,7 +300,7 @@ impl<S: BundleSource> KibanaBundle<S> {
     fn read_skills(&self, space_id: &str) -> Result<Vec<Value>> {
         let root = resource_dir(space_id, "skills");
         let manifest_path = manifest_path(space_id, "skills.yml");
-        let manifest: Option<SkillsManifest> = if self.source.is_file(&manifest_path) {
+        let manifest: Option<SkillsManifest> = if self.manifest_is_file(&manifest_path)? {
             Some(self.read_yaml_manifest(&manifest_path, "skills")?)
         } else {
             None
@@ -373,7 +373,7 @@ impl<S: BundleSource> KibanaBundle<S> {
 
     fn read_spaces(&self) -> Result<Vec<Value>> {
         let path = Path::new("spaces.yml");
-        if !self.source.is_file(path) {
+        if !self.manifest_is_file(path)? {
             return Ok(Vec::new());
         }
         let manifest: SpacesManifest = self.read_yaml_manifest(path, "spaces")?;
@@ -423,7 +423,7 @@ impl<S: BundleSource> KibanaBundle<S> {
     fn discover_space_ids(&self) -> Result<Vec<String>> {
         let mut ids = BTreeSet::new();
         let spaces_path = Path::new("spaces.yml");
-        if self.source.is_file(spaces_path) {
+        if self.manifest_is_file(spaces_path)? {
             let manifest: SpacesManifest = self.read_yaml_manifest(spaces_path, "spaces")?;
             ids.extend(manifest.spaces.into_iter().map(|space| space.id));
         }
@@ -449,6 +449,19 @@ impl<S: BundleSource> KibanaBundle<S> {
         ]
         .into_iter()
         .any(|name| self.source.is_dir(&resource_dir(space_id, name)))
+    }
+
+    fn manifest_is_file(&self, path: &Path) -> Result<bool> {
+        if self.source.is_file(path) {
+            return Ok(true);
+        }
+        if self.source.is_dir(path) {
+            return Err(Error::message(format!(
+                "bundle manifest must be a file: {}",
+                self.source.display_path(path)
+            )));
+        }
+        Ok(false)
     }
 
     fn read_json_dir(&self, directory: &Path) -> Result<Vec<Value>> {
@@ -1309,6 +1322,24 @@ mod tests {
         .unwrap_err();
 
         assert!(error.to_string().contains("invalid space id '../outside'"));
+    }
+
+    #[test]
+    fn bundle_reader_rejects_manifest_directories() {
+        for entries in [
+            vec![("spaces.yml/marker", b"directory".as_slice())],
+            vec![(
+                "default/manifest/tools.yml/marker",
+                b"directory".as_slice(),
+            )],
+        ] {
+            let error = KibanaBundle::from_entries(entries)
+                .unwrap()
+                .read_all()
+                .unwrap_err();
+
+            assert!(error.to_string().contains("bundle manifest must be a file"));
+        }
     }
 
     #[test]

--- a/crates/kibana-sync/src/bundle.rs
+++ b/crates/kibana-sync/src/bundle.rs
@@ -548,12 +548,19 @@ impl BundleSource for Filesystem {
     }
 
     fn read(&self, path: &Path) -> Result<Self::Content<'_>> {
-        let path = self.root.join(path);
-        let metadata = std::fs::symlink_metadata(&path)?;
-        if metadata.file_type().is_symlink() {
-            return Err(bundle_symlink_error(&path));
+        let mut full_path = self.root.clone();
+        for component in path.components() {
+            full_path.push(component);
+            let metadata = std::fs::symlink_metadata(&full_path)?;
+            if metadata.file_type().is_symlink() {
+                return Err(bundle_symlink_error(&full_path));
+            }
         }
-        std::fs::read(path).map_err(Into::into)
+        let metadata = std::fs::symlink_metadata(&full_path)?;
+        if metadata.file_type().is_symlink() {
+            return Err(bundle_symlink_error(&full_path));
+        }
+        std::fs::read(full_path).map_err(Into::into)
     }
 
     fn files_under(&self, path: &Path) -> Result<Vec<PathBuf>> {

--- a/crates/kibana-sync/src/bundle.rs
+++ b/crates/kibana-sync/src/bundle.rs
@@ -2,7 +2,9 @@
 
 use crate::kibana::agents::AgentsManifest;
 use crate::kibana::saved_objects::SavedObjectsManifest;
-use crate::kibana::skills::{SkillsManifest, skill_files_to_value};
+use crate::kibana::skills::{
+    REFERENCED_CONTENT_METADATA_FILE, SKILL_FILE, SkillsManifest, skill_files_to_value,
+};
 use crate::kibana::spaces::{SpaceEntry, SpacesManifest};
 use crate::kibana::tools::ToolsManifest;
 use crate::kibana::workflows::WorkflowsManifest;
@@ -314,13 +316,13 @@ impl<S: BundleSource> KibanaBundle<S> {
         directories.sort();
         let mut values = Vec::new();
         for directory in directories {
-            let skill_file = directory.join("SKILL.md");
+            let skill_file = directory.join(SKILL_FILE);
             if !self.source.is_file(&skill_file) {
                 continue;
             }
             self.source.validate_skill_directory(&directory)?;
             let skill_markdown = self.read_text(&skill_file, "skill file")?;
-            let metadata_path = directory.join(".referenced_content.yml");
+            let metadata_path = directory.join(REFERENCED_CONTENT_METADATA_FILE);
             let metadata = self
                 .source
                 .is_file(&metadata_path)
@@ -329,7 +331,7 @@ impl<S: BundleSource> KibanaBundle<S> {
             let mut referenced = Vec::new();
             for file in self.source.files_under(&directory)? {
                 if file.extension().and_then(|value| value.to_str()) != Some("md")
-                    || file.file_name().and_then(|value| value.to_str()) == Some("SKILL.md")
+                    || file.file_name().and_then(|value| value.to_str()) == Some(SKILL_FILE)
                 {
                     continue;
                 }

--- a/crates/kibana-sync/src/bundle.rs
+++ b/crates/kibana-sync/src/bundle.rs
@@ -381,7 +381,12 @@ impl<S: BundleSource> KibanaBundle<S> {
             return Ok(serde_json::json!({"id": space.id, "name": space.name}));
         }
 
-        let content = self.source.read(&path)?;
+        let content = self.source.read(&path).with_context(|| {
+            format!(
+                "Failed to read space definition: {}",
+                self.source.display_path(&path)
+            )
+        })?;
         let text = utf8(content.as_ref(), &self.source.display_path(&path))?;
         let definition = json5::from_json5_str(text).with_context(|| {
             format!(
@@ -442,7 +447,12 @@ impl<S: BundleSource> KibanaBundle<S> {
         files
             .into_iter()
             .map(|path| {
-                let content = self.source.read(&path)?;
+                let content = self.source.read(&path).with_context(|| {
+                    format!(
+                        "Failed to read JSON resource: {}",
+                        self.source.display_path(&path)
+                    )
+                })?;
                 let text = utf8(content.as_ref(), &self.source.display_path(&path))?;
                 json5::from_json5_str(text).with_context(|| {
                     format!(

--- a/crates/kibana-sync/src/bundle.rs
+++ b/crates/kibana-sync/src/bundle.rs
@@ -22,7 +22,7 @@ mod sealed {
 /// Read operations required by [`KibanaBundle`].
 ///
 /// This trait is sealed. Use [`Filesystem`] or [`Entries`] as the source.
-pub(crate) trait BundleSource: sealed::Sealed {
+pub trait BundleSource: sealed::Sealed {
     /// Borrowed or owned content returned by this source.
     type Content<'a>: AsRef<[u8]>
     where
@@ -181,6 +181,7 @@ impl<S: BundleSource> KibanaBundle<S> {
         }
 
         for space_id in &selection.spaces {
+            validate_space_id(space_id)?;
             let mut space_bundle = SpaceBundle::default();
             if let Some(selection_manifest) = &selection.saved_objects {
                 space_bundle.saved_objects =
@@ -379,7 +380,10 @@ impl<S: BundleSource> KibanaBundle<S> {
         manifest
             .spaces
             .into_iter()
-            .map(|space| self.read_space_definition(&space))
+            .map(|space| {
+                validate_space_id(&space.id)?;
+                self.read_space_definition(&space)
+            })
             .collect()
     }
 
@@ -709,6 +713,18 @@ fn normalize_entry_path(path: &Path) -> Result<PathBuf> {
         )));
     }
     Ok(normalized)
+}
+
+pub(crate) fn validate_space_id(id: &str) -> Result<()> {
+    if id.is_empty()
+        || matches!(id, "." | "..")
+        || id.contains(['/', '\\', ':'])
+    {
+        return Err(Error::message(format!(
+            "invalid space id '{id}': space ids must be a single path component"
+        )));
+    }
+    Ok(())
 }
 
 fn logical_path(path: &Path) -> String {
@@ -1262,5 +1278,53 @@ mod tests {
         let error = filesystem.write(&bundle).unwrap_err();
 
         assert_eq!(error.to_string(), "space must be a JSON object");
+    }
+
+    #[test]
+    fn bundle_reader_rejects_path_traversal_space_ids() {
+        let selection = SyncSelection {
+            spaces: vec!["../outside".to_string()],
+            include_tools: true,
+            ..SyncSelection::default()
+        };
+        let error = KibanaBundle::<Entries<&[u8]>>::from_entries(std::iter::empty::<(
+            &str,
+            &[u8],
+        )>())
+        .unwrap()
+            .read(&selection)
+            .unwrap_err();
+
+        assert!(error.to_string().contains("invalid space id '../outside'"));
+    }
+
+    #[test]
+    fn bundle_reader_rejects_path_traversal_space_manifest_ids() {
+        let error = KibanaBundle::from_entries([(
+            "spaces.yml",
+            b"spaces:\n  - id: ../outside\n    name: Outside\n".as_slice(),
+        )])
+        .unwrap()
+        .read_all()
+        .unwrap_err();
+
+        assert!(error.to_string().contains("invalid space id '../outside'"));
+    }
+
+    #[test]
+    fn filesystem_write_rejects_path_traversal_space_ids() {
+        let temp = TempDir::new().unwrap();
+        let filesystem = KibanaBundle::create(temp.path()).unwrap();
+        let bundle = SyncBundle {
+            by_space: std::collections::HashMap::from([(
+                "../outside".to_string(),
+                SpaceBundle::default(),
+            )]),
+            ..SyncBundle::default()
+        };
+
+        let error = filesystem.write(&bundle).unwrap_err();
+
+        assert!(error.to_string().contains("invalid space id '../outside'"));
     }
 }

--- a/crates/kibana-sync/src/bundle.rs
+++ b/crates/kibana-sync/src/bundle.rs
@@ -22,7 +22,7 @@ mod sealed {
 /// Read operations required by [`KibanaBundle`].
 ///
 /// This trait is sealed. Use [`Filesystem`] or [`Entries`] as the source.
-pub trait BundleSource: sealed::Sealed {
+pub(crate) trait BundleSource: sealed::Sealed {
     /// Borrowed or owned content returned by this source.
     type Content<'a>: AsRef<[u8]>
     where
@@ -653,9 +653,8 @@ impl<B: AsRef<[u8]>> BundleSource for Entries<B> {
     fn files_under(&self, path: &Path) -> Result<Vec<PathBuf>> {
         Ok(self
             .files
-            .range(path.to_path_buf()..)
-            .take_while(|(entry, _)| entry.starts_with(path))
-            .map(|(entry, _)| entry)
+            .keys()
+            .filter(|entry| entry.starts_with(path))
             .cloned()
             .collect())
     }
@@ -1021,6 +1020,26 @@ mod tests {
     }
 
     #[test]
+    fn entry_files_under_does_not_stop_at_lexicographic_siblings() {
+        let bundle = KibanaBundle::from_entries([
+            ("default/skills/incident-response/SKILL.md", b"skill".as_slice()),
+            (
+                "default/skills/incident-response-v2/notes.md",
+                b"sibling".as_slice(),
+            ),
+        ])
+        .unwrap();
+
+        assert_eq!(
+            bundle
+                .source
+                .files_under(Path::new("default/skills/incident-response"))
+                .unwrap(),
+            vec![PathBuf::from("default/skills/incident-response/SKILL.md")]
+        );
+    }
+
+    #[test]
     fn entry_errors_include_logical_paths() {
         let invalid_utf8 = KibanaBundle::from_entries([("spaces.yml", [0xff])])
             .unwrap()
@@ -1229,5 +1248,19 @@ mod tests {
             read.spaces,
             vec![json!({"id": "default", "name": "default"})]
         );
+    }
+
+    #[test]
+    fn filesystem_write_rejects_non_object_spaces() {
+        let temp = TempDir::new().unwrap();
+        let filesystem = KibanaBundle::create(temp.path()).unwrap();
+        let bundle = SyncBundle {
+            spaces: vec![json!("default")],
+            ..SyncBundle::default()
+        };
+
+        let error = filesystem.write(&bundle).unwrap_err();
+
+        assert_eq!(error.to_string(), "space must be a JSON object");
     }
 }

--- a/crates/kibana-sync/src/bundle.rs
+++ b/crates/kibana-sync/src/bundle.rs
@@ -565,7 +565,15 @@ impl BundleSource for Filesystem {
 
     fn immediate_directories(&self, path: &Path) -> Result<Vec<PathBuf>> {
         let directory = self.root.join(path);
-        if !directory.is_dir() {
+        let metadata = match std::fs::symlink_metadata(&directory) {
+            Ok(metadata) => metadata,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+            Err(error) => return Err(error.into()),
+        };
+        if metadata.file_type().is_symlink() {
+            return Err(bundle_symlink_error(&directory));
+        }
+        if !metadata.is_dir() {
             return Ok(Vec::new());
         }
         let mut directories = Vec::new();

--- a/crates/kibana-sync/src/bundle.rs
+++ b/crates/kibana-sync/src/bundle.rs
@@ -1,0 +1,1052 @@
+//! Generic bundle access for filesystem and in-memory Kibana assets.
+
+use crate::kibana::agents::AgentsManifest;
+use crate::kibana::saved_objects::SavedObjectsManifest;
+use crate::kibana::skills::{SkillsManifest, skill_files_to_value};
+use crate::kibana::spaces::{SpaceEntry, SpacesManifest};
+use crate::kibana::tools::ToolsManifest;
+use crate::kibana::workflows::WorkflowsManifest;
+use crate::sync::{SpaceBundle, SyncBundle, SyncSelection};
+use crate::{Error, Result, ResultContext, json5};
+use serde::de::DeserializeOwned;
+use serde_json::Value;
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Component, Path, PathBuf};
+
+mod sealed {
+    pub trait Sealed {}
+}
+
+/// Read operations required by [`KibanaBundle`].
+///
+/// This trait is sealed. Use [`Filesystem`] or [`Entries`] as the source.
+pub trait BundleSource: sealed::Sealed {
+    /// Borrowed or owned content returned by this source.
+    type Content<'a>: AsRef<[u8]>
+    where
+        Self: 'a;
+
+    #[doc(hidden)]
+    fn is_file(&self, path: &Path) -> bool;
+    #[doc(hidden)]
+    fn is_dir(&self, path: &Path) -> bool;
+    #[doc(hidden)]
+    fn read(&self, path: &Path) -> Result<Self::Content<'_>>;
+    #[doc(hidden)]
+    fn files_under(&self, path: &Path) -> Result<Vec<PathBuf>>;
+    #[doc(hidden)]
+    fn immediate_directories(&self, path: &Path) -> Result<Vec<PathBuf>>;
+    #[doc(hidden)]
+    fn display_path(&self, path: &Path) -> String;
+    #[doc(hidden)]
+    fn validate_skill_directory(&self, _path: &Path) -> Result<()> {
+        Ok(())
+    }
+}
+
+/// A Kibana asset bundle backed by a source type.
+#[derive(Clone, Debug)]
+pub struct KibanaBundle<S> {
+    source: S,
+}
+
+/// Filesystem-backed bundle source.
+#[derive(Clone, Debug)]
+pub struct Filesystem {
+    root: PathBuf,
+}
+
+/// Entry-backed bundle source with caller-selected byte storage.
+#[derive(Clone, Debug)]
+pub struct Entries<B> {
+    files: BTreeMap<PathBuf, B>,
+    directories: BTreeSet<PathBuf>,
+}
+
+impl sealed::Sealed for Filesystem {}
+impl<B> sealed::Sealed for Entries<B> {}
+
+impl KibanaBundle<Filesystem> {
+    /// Open an existing filesystem bundle.
+    pub fn open(root: impl AsRef<Path>) -> Result<Self> {
+        let root = root.as_ref().to_path_buf();
+        if !root.exists() {
+            return Err(Error::message(format!(
+                "filesystem bundle root does not exist: {}",
+                root.display()
+            )));
+        }
+        Ok(Self {
+            source: Filesystem { root },
+        })
+    }
+
+    /// Create or open a filesystem bundle.
+    pub fn create(root: impl AsRef<Path>) -> Result<Self> {
+        let root = root.as_ref().to_path_buf();
+        std::fs::create_dir_all(&root)
+            .with_context(|| format!("Failed to create bundle root: {}", root.display()))?;
+        Ok(Self {
+            source: Filesystem { root },
+        })
+    }
+
+    /// Return the filesystem bundle root.
+    pub fn root(&self) -> &Path {
+        &self.source.root
+    }
+
+    /// Write a storage-neutral bundle to the stable filesystem layout.
+    pub fn write(&self, bundle: &SyncBundle) -> Result<()> {
+        crate::fs::FilesystemWriter::create(&self.source.root)?.write(bundle)
+    }
+}
+
+impl<B: AsRef<[u8]>> KibanaBundle<Entries<B>> {
+    /// Construct a bundle from root-relative path and content pairs.
+    pub fn from_entries<P>(entries: impl IntoIterator<Item = (P, B)>) -> Result<Self>
+    where
+        P: AsRef<Path>,
+    {
+        let mut files = BTreeMap::new();
+        let mut directories = BTreeSet::new();
+
+        for (path, content) in entries {
+            let original = path.as_ref();
+            let normalized = normalize_entry_path(original)?;
+            if directories.contains(&normalized) {
+                return Err(Error::message(format!(
+                    "bundle entry path conflicts with an implicit directory: {}",
+                    normalized.display()
+                )));
+            }
+            if files.insert(normalized.clone(), content).is_some() {
+                return Err(Error::message(format!(
+                    "duplicate bundle entry path: {}",
+                    normalized.display()
+                )));
+            }
+
+            let mut parent = normalized.parent();
+            while let Some(directory) = parent {
+                if directory.as_os_str().is_empty() {
+                    break;
+                }
+                if files.contains_key(directory) {
+                    return Err(Error::message(format!(
+                        "bundle entry path conflicts with a file: {}",
+                        directory.display()
+                    )));
+                }
+                directories.insert(directory.to_path_buf());
+                parent = directory.parent();
+            }
+        }
+
+        Ok(Self {
+            source: Entries { files, directories },
+        })
+    }
+}
+
+impl<S: BundleSource> KibanaBundle<S> {
+    /// Read all resource families discoverable in the bundle.
+    pub fn read_all(&self) -> Result<SyncBundle> {
+        let spaces = self.discover_space_ids()?;
+        let selection = SyncSelection {
+            spaces,
+            saved_objects: Some(SavedObjectsManifest::new()),
+            include_spaces: self.source.is_file(Path::new("spaces.yml")),
+            include_workflows: true,
+            include_agents: true,
+            include_tools: true,
+            include_skills: true,
+        };
+        self.read(&selection)
+    }
+
+    /// Read selected resource families into a storage-neutral bundle.
+    pub fn read(&self, selection: &SyncSelection) -> Result<SyncBundle> {
+        let mut bundle = SyncBundle::default();
+        if selection.include_spaces {
+            bundle.spaces = self.read_spaces()?;
+        }
+
+        for space_id in &selection.spaces {
+            let mut space_bundle = SpaceBundle::default();
+            if let Some(selection_manifest) = &selection.saved_objects {
+                space_bundle.saved_objects =
+                    self.read_saved_objects(space_id, selection_manifest)?;
+            }
+            if selection.include_workflows {
+                space_bundle.workflows = self.read_workflows(space_id)?;
+            }
+            if selection.include_agents {
+                space_bundle.agents = self.read_agents(space_id)?;
+            }
+            if selection.include_tools {
+                space_bundle.tools = self.read_tools(space_id)?;
+            }
+            if selection.include_skills {
+                space_bundle.skills = self.read_skills(space_id)?;
+            }
+            bundle.by_space.insert(space_id.clone(), space_bundle);
+        }
+        Ok(bundle)
+    }
+
+    fn read_saved_objects(
+        &self,
+        space_id: &str,
+        selection_manifest: &SavedObjectsManifest,
+    ) -> Result<Vec<Value>> {
+        let directory = resource_dir(space_id, "objects");
+        let values = self.read_json_dir(&directory)?;
+        let manifest_path = manifest_path(space_id, "saved_objects.json");
+        let manifest = if self.source.is_file(&manifest_path) {
+            Some(self.read_json_manifest(&manifest_path, "saved objects")?)
+        } else if selection_manifest.objects.is_empty() {
+            None
+        } else {
+            Some(selection_manifest.clone())
+        };
+
+        let Some(manifest) = manifest else {
+            return Ok(values);
+        };
+        manifest
+            .objects
+            .iter()
+            .map(|object| {
+                values
+                    .iter()
+                    .find(|value| saved_object_matches(value, &object.object_type, &object.id))
+                    .cloned()
+                    .ok_or_else(|| {
+                        self.missing_manifest_resource(
+                            "saved object",
+                            format!("{}/{}", object.object_type, object.id),
+                            &directory,
+                        )
+                    })
+            })
+            .collect()
+    }
+
+    fn read_workflows(&self, space_id: &str) -> Result<Vec<Value>> {
+        let directory = resource_dir(space_id, "workflows");
+        let values = self.read_json_dir(&directory)?;
+        let manifest_path = manifest_path(space_id, "workflows.yml");
+        if !self.source.is_file(&manifest_path) {
+            return Ok(values);
+        }
+        let manifest: WorkflowsManifest = self.read_yaml_manifest(&manifest_path, "workflows")?;
+        manifest
+            .workflows
+            .iter()
+            .map(|entry| {
+                find_named_resource(&values, &entry.id, Some(&entry.name)).ok_or_else(|| {
+                    self.missing_manifest_resource("workflow", &entry.id, &directory)
+                })
+            })
+            .collect()
+    }
+
+    fn read_agents(&self, space_id: &str) -> Result<Vec<Value>> {
+        let directory = resource_dir(space_id, "agents");
+        let values = self.read_json_dir(&directory)?;
+        let manifest_path = manifest_path(space_id, "agents.yml");
+        if !self.source.is_file(&manifest_path) {
+            return Ok(values);
+        }
+        let manifest: AgentsManifest = self.read_yaml_manifest(&manifest_path, "agents")?;
+        manifest
+            .agents
+            .iter()
+            .map(|entry| {
+                find_named_resource(&values, &entry.id, Some(&entry.name))
+                    .ok_or_else(|| self.missing_manifest_resource("agent", &entry.id, &directory))
+            })
+            .collect()
+    }
+
+    fn read_tools(&self, space_id: &str) -> Result<Vec<Value>> {
+        let directory = resource_dir(space_id, "tools");
+        let values = self.read_json_dir(&directory)?;
+        let manifest_path = manifest_path(space_id, "tools.yml");
+        if !self.source.is_file(&manifest_path) {
+            return Ok(values);
+        }
+        let manifest: ToolsManifest = self.read_yaml_manifest(&manifest_path, "tools")?;
+        manifest
+            .tools
+            .iter()
+            .map(|id| {
+                find_named_resource(&values, id, None)
+                    .ok_or_else(|| self.missing_manifest_resource("tool", id, &directory))
+            })
+            .collect()
+    }
+
+    fn read_skills(&self, space_id: &str) -> Result<Vec<Value>> {
+        let root = resource_dir(space_id, "skills");
+        let manifest_path = manifest_path(space_id, "skills.yml");
+        let manifest: Option<SkillsManifest> = if self.source.is_file(&manifest_path) {
+            Some(self.read_yaml_manifest(&manifest_path, "skills")?)
+        } else {
+            None
+        };
+
+        if !self.source.is_dir(&root) {
+            if let Some(entry) = manifest.as_ref().and_then(|value| value.skills.first()) {
+                return Err(self.missing_skill_manifest_resource(&entry.id, &root));
+            }
+            return Ok(Vec::new());
+        }
+
+        let mut directories = self.source.immediate_directories(&root)?;
+        directories.sort();
+        let mut values = Vec::new();
+        for directory in directories {
+            let skill_file = directory.join("SKILL.md");
+            if !self.source.is_file(&skill_file) {
+                continue;
+            }
+            self.source.validate_skill_directory(&directory)?;
+            let skill_markdown = self.read_text(&skill_file, "skill file")?;
+            let metadata_path = directory.join(".referenced_content.yml");
+            let metadata = self
+                .source
+                .is_file(&metadata_path)
+                .then(|| self.read_text(&metadata_path, "referenced content metadata"))
+                .transpose()?;
+            let mut referenced = Vec::new();
+            for file in self.source.files_under(&directory)? {
+                if file.extension().and_then(|value| value.to_str()) != Some("md")
+                    || file.file_name().and_then(|value| value.to_str()) == Some("SKILL.md")
+                {
+                    continue;
+                }
+                let relative = file
+                    .strip_prefix(&directory)
+                    .map_err(|_| {
+                        Error::message(format!(
+                            "referenced content escaped skill directory: {}",
+                            self.source.display_path(&file)
+                        ))
+                    })?
+                    .to_path_buf();
+                referenced.push((relative, self.read_text(&file, "referenced content")?));
+            }
+            values.push(skill_files_to_value(
+                &skill_markdown,
+                referenced,
+                metadata.as_deref(),
+                true,
+            )?);
+        }
+
+        let Some(manifest) = manifest else {
+            return Ok(values);
+        };
+        manifest
+            .skills
+            .iter()
+            .map(|entry| {
+                values
+                    .iter()
+                    .find(|value| value.get("id").and_then(Value::as_str) == Some(&entry.id))
+                    .cloned()
+                    .ok_or_else(|| self.missing_skill_manifest_resource(&entry.id, &root))
+            })
+            .collect()
+    }
+
+    fn read_spaces(&self) -> Result<Vec<Value>> {
+        let path = Path::new("spaces.yml");
+        if !self.source.is_file(path) {
+            return Ok(Vec::new());
+        }
+        let manifest: SpacesManifest = self.read_yaml_manifest(path, "spaces")?;
+        manifest
+            .spaces
+            .into_iter()
+            .map(|space| self.read_space_definition(&space))
+            .collect()
+    }
+
+    fn read_space_definition(&self, space: &SpaceEntry) -> Result<Value> {
+        let path = Path::new(&space.id).join("space.json");
+        if !self.source.is_file(&path) {
+            return Ok(serde_json::json!({"id": space.id, "name": space.name}));
+        }
+
+        let content = self.source.read(&path)?;
+        let text = utf8(content.as_ref(), &self.source.display_path(&path))?;
+        let definition = json5::from_json5_str(text).with_context(|| {
+            format!(
+                "Failed to parse space definition: {}",
+                self.source.display_path(&path)
+            )
+        })?;
+        let id = definition.get("id").and_then(Value::as_str);
+        let name = definition.get("name").and_then(Value::as_str);
+        if id != Some(space.id.as_str()) || name.is_none() {
+            return Err(Error::message(format!(
+                "space definition {} must contain the manifest id '{}' and a name",
+                self.source.display_path(&path),
+                space.id
+            )));
+        }
+        Ok(definition)
+    }
+
+    fn discover_space_ids(&self) -> Result<Vec<String>> {
+        let mut ids = BTreeSet::new();
+        let spaces_path = Path::new("spaces.yml");
+        if self.source.is_file(spaces_path) {
+            let manifest: SpacesManifest = self.read_yaml_manifest(spaces_path, "spaces")?;
+            ids.extend(manifest.spaces.into_iter().map(|space| space.id));
+        }
+        for directory in self.source.immediate_directories(Path::new(""))? {
+            let Some(id) = directory.file_name().and_then(|value| value.to_str()) else {
+                continue;
+            };
+            if self.has_space_resources(id) {
+                ids.insert(id.to_string());
+            }
+        }
+        Ok(ids.into_iter().collect())
+    }
+
+    fn has_space_resources(&self, space_id: &str) -> bool {
+        [
+            "objects",
+            "workflows",
+            "agents",
+            "tools",
+            "skills",
+            "manifest",
+        ]
+        .into_iter()
+        .any(|name| self.source.is_dir(&resource_dir(space_id, name)))
+    }
+
+    fn read_json_dir(&self, directory: &Path) -> Result<Vec<Value>> {
+        if !self.source.is_dir(directory) {
+            return Ok(Vec::new());
+        }
+        let mut files = self.source.files_under(directory)?;
+        files.retain(|path| path.extension().and_then(|value| value.to_str()) == Some("json"));
+        files.sort();
+        files
+            .into_iter()
+            .map(|path| {
+                let content = self.source.read(&path)?;
+                let text = utf8(content.as_ref(), &self.source.display_path(&path))?;
+                json5::from_json5_str(text).with_context(|| {
+                    format!(
+                        "Failed to parse JSON resource: {}",
+                        self.source.display_path(&path)
+                    )
+                })
+            })
+            .collect()
+    }
+
+    fn read_text(&self, path: &Path, resource: &str) -> Result<String> {
+        let content = self.source.read(path).with_context(|| {
+            format!(
+                "Failed to read {resource}: {}",
+                self.source.display_path(path)
+            )
+        })?;
+        Ok(utf8(content.as_ref(), &self.source.display_path(path))?.to_string())
+    }
+
+    fn read_yaml_manifest<T: DeserializeOwned>(&self, path: &Path, kind: &str) -> Result<T> {
+        let content = self.source.read(path).with_context(|| {
+            format!(
+                "Failed to read {kind} manifest: {}",
+                self.source.display_path(path)
+            )
+        })?;
+        let text = utf8(content.as_ref(), &self.source.display_path(path))?;
+        yaml_serde::from_str(text).with_context(|| format!("Failed to parse {kind} manifest YAML"))
+    }
+
+    fn read_json_manifest<T: DeserializeOwned>(&self, path: &Path, kind: &str) -> Result<T> {
+        let content = self.source.read(path).with_context(|| {
+            format!(
+                "Failed to read {kind} manifest: {}",
+                self.source.display_path(path)
+            )
+        })?;
+        let text = utf8(content.as_ref(), &self.source.display_path(path))?;
+        serde_json::from_str(text).with_context(|| format!("Failed to parse {kind} manifest JSON"))
+    }
+
+    fn missing_manifest_resource(
+        &self,
+        resource: &str,
+        id: impl std::fmt::Display,
+        directory: &Path,
+    ) -> Error {
+        Error::message(format!(
+            "{resource} '{id}' is listed in the manifest but no matching JSON resource was found under {}",
+            self.source.display_path(directory)
+        ))
+    }
+
+    fn missing_skill_manifest_resource(
+        &self,
+        id: impl std::fmt::Display,
+        directory: &Path,
+    ) -> Error {
+        Error::message(format!(
+            "skill '{id}' is listed in the manifest but no matching skills/<skill-directory>/SKILL.md resource was found under {}",
+            self.source.display_path(directory)
+        ))
+    }
+}
+
+impl BundleSource for Filesystem {
+    type Content<'a> = Vec<u8>;
+
+    fn is_file(&self, path: &Path) -> bool {
+        self.root.join(path).is_file()
+    }
+
+    fn is_dir(&self, path: &Path) -> bool {
+        self.root.join(path).is_dir()
+    }
+
+    fn read(&self, path: &Path) -> Result<Self::Content<'_>> {
+        std::fs::read(self.root.join(path)).map_err(Into::into)
+    }
+
+    fn files_under(&self, path: &Path) -> Result<Vec<PathBuf>> {
+        let mut files = Vec::new();
+        collect_files(&self.root, &self.root.join(path), &mut files)?;
+        Ok(files)
+    }
+
+    fn immediate_directories(&self, path: &Path) -> Result<Vec<PathBuf>> {
+        let directory = self.root.join(path);
+        if !directory.is_dir() {
+            return Ok(Vec::new());
+        }
+        let mut directories = Vec::new();
+        for entry in std::fs::read_dir(directory)? {
+            let entry = entry?;
+            if entry.path().is_dir() {
+                directories.push(path.join(entry.file_name()));
+            }
+        }
+        directories.sort();
+        Ok(directories)
+    }
+
+    fn display_path(&self, path: &Path) -> String {
+        self.root.join(path).display().to_string()
+    }
+
+    fn validate_skill_directory(&self, path: &Path) -> Result<()> {
+        let directory = self.root.join(path);
+        let metadata = std::fs::symlink_metadata(&directory)?;
+        if metadata.file_type().is_symlink() {
+            return Err(Error::message(format!(
+                "skill directory cannot be a symlink: {}",
+                directory.display()
+            )));
+        }
+        let canonical = directory.canonicalize().with_context(|| {
+            format!("Failed to resolve skill directory: {}", directory.display())
+        })?;
+        validate_filesystem_tree(&canonical, &directory)
+    }
+}
+
+impl<B: AsRef<[u8]>> BundleSource for Entries<B> {
+    type Content<'a>
+        = &'a B
+    where
+        B: 'a;
+
+    fn is_file(&self, path: &Path) -> bool {
+        self.files.contains_key(path)
+    }
+
+    fn is_dir(&self, path: &Path) -> bool {
+        path.as_os_str().is_empty() || self.directories.contains(path)
+    }
+
+    fn read(&self, path: &Path) -> Result<Self::Content<'_>> {
+        self.files.get(path).ok_or_else(|| {
+            Error::message(format!("bundle entry does not exist: {}", path.display()))
+        })
+    }
+
+    fn files_under(&self, path: &Path) -> Result<Vec<PathBuf>> {
+        Ok(self
+            .files
+            .keys()
+            .filter(|entry| entry.starts_with(path))
+            .cloned()
+            .collect())
+    }
+
+    fn immediate_directories(&self, path: &Path) -> Result<Vec<PathBuf>> {
+        Ok(self
+            .directories
+            .iter()
+            .filter(|directory| directory.parent().unwrap_or_else(|| Path::new("")) == path)
+            .cloned()
+            .collect())
+    }
+
+    fn display_path(&self, path: &Path) -> String {
+        path.display().to_string()
+    }
+}
+
+fn normalize_entry_path(path: &Path) -> Result<PathBuf> {
+    let original = path.to_str().ok_or_else(|| {
+        Error::message(format!(
+            "bundle entry path is not UTF-8: {}",
+            path.display()
+        ))
+    })?;
+    if original.is_empty() {
+        return Err(Error::message("invalid bundle entry path: path is empty"));
+    }
+    let logical = original.replace('\\', "/");
+    if logical.starts_with('/')
+        || logical.as_bytes().get(1) == Some(&b':') && logical.as_bytes()[0].is_ascii_alphabetic()
+    {
+        return Err(Error::message(format!(
+            "invalid bundle entry path '{original}': path must be relative"
+        )));
+    }
+
+    let mut normalized = PathBuf::new();
+    for component in Path::new(&logical).components() {
+        match component {
+            Component::Normal(value) => normalized.push(value),
+            _ => {
+                return Err(Error::message(format!(
+                    "invalid bundle entry path '{original}': only normal relative components are allowed"
+                )));
+            }
+        }
+    }
+    if normalized.as_os_str().is_empty() || logical.ends_with('/') {
+        return Err(Error::message(format!(
+            "invalid bundle entry path '{original}': path must name a file"
+        )));
+    }
+    Ok(normalized)
+}
+
+fn collect_files(root: &Path, directory: &Path, files: &mut Vec<PathBuf>) -> Result<()> {
+    if !directory.is_dir() {
+        return Ok(());
+    }
+    for entry in std::fs::read_dir(directory)? {
+        let path = entry?.path();
+        if path.is_dir() {
+            collect_files(root, &path, files)?;
+        } else if path.is_file() {
+            files.push(
+                path.strip_prefix(root)
+                    .map_err(|_| {
+                        Error::message(format!("bundle file escaped root: {}", path.display()))
+                    })?
+                    .to_path_buf(),
+            );
+        }
+    }
+    files.sort();
+    Ok(())
+}
+
+fn validate_filesystem_tree(canonical_root: &Path, directory: &Path) -> Result<()> {
+    for entry in std::fs::read_dir(directory)? {
+        let path = entry?.path();
+        let metadata = std::fs::symlink_metadata(&path)
+            .with_context(|| format!("Failed to inspect path: {}", path.display()))?;
+        if metadata.file_type().is_symlink() {
+            return Err(Error::message(format!(
+                "path uses symlink traversal inside skill directory: {}",
+                path.display()
+            )));
+        }
+        let canonical = path
+            .canonicalize()
+            .with_context(|| format!("Failed to resolve path: {}", path.display()))?;
+        if !canonical.starts_with(canonical_root) {
+            return Err(Error::message(format!(
+                "path escapes skill directory: {}",
+                path.display()
+            )));
+        }
+        if metadata.is_dir() {
+            validate_filesystem_tree(canonical_root, &path)?;
+        }
+    }
+    Ok(())
+}
+
+fn utf8<'a>(content: &'a [u8], path: &str) -> Result<&'a str> {
+    std::str::from_utf8(content)
+        .map_err(|error| Error::message(format!("bundle text file is not UTF-8: {path}: {error}")))
+}
+
+fn resource_dir(space_id: &str, name: &str) -> PathBuf {
+    Path::new(space_id).join(name)
+}
+
+fn manifest_path(space_id: &str, name: &str) -> PathBuf {
+    Path::new(space_id).join("manifest").join(name)
+}
+
+fn saved_object_matches(value: &Value, object_type: &str, id: &str) -> bool {
+    value.get("type").and_then(Value::as_str) == Some(object_type)
+        && value.get("id").and_then(Value::as_str) == Some(id)
+}
+
+fn find_named_resource(values: &[Value], id: &str, name: Option<&str>) -> Option<Value> {
+    values
+        .iter()
+        .find(|value| value.get("id").and_then(Value::as_str) == Some(id))
+        .or_else(|| {
+            name.and_then(|name| {
+                values
+                    .iter()
+                    .find(|value| value.get("name").and_then(Value::as_str) == Some(name))
+            })
+        })
+        .cloned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::sync::Arc;
+    use tempfile::TempDir;
+
+    struct ApplicationBytes(Vec<u8>);
+
+    impl AsRef<[u8]> for ApplicationBytes {
+        fn as_ref(&self) -> &[u8] {
+            &self.0
+        }
+    }
+
+    fn fixture() -> Vec<(String, Vec<u8>)> {
+        [
+            ("spaces.yml", "spaces:\n  - id: default\n    name: Default\n"),
+            ("default/manifest/saved_objects.json", r#"{"objects":[{"type":"dashboard","id":"dash-1"}]}"#),
+            ("default/objects/dashboard/dash-1.json", r#"{
+                // JSON5 comments, unquoted keys, and trailing commas are valid.
+                type: "dashboard",
+                id: "dash-1",
+                attributes: { title: "Dash", },
+            }"#),
+            ("default/manifest/workflows.yml", "workflows:\n  - id: workflow-1\n    name: Workflow\n"),
+            ("default/workflows/workflow.json", r#"{"id":"workflow-1","name":"Workflow"}"#),
+            ("default/manifest/agents.yml", "agents:\n  - id: agent-1\n    name: Agent\n"),
+            ("default/agents/agent.json", r#"{"id":"agent-1","name":"Agent"}"#),
+            ("default/manifest/tools.yml", "tools:\n  - tool-1\n"),
+            ("default/tools/tool.json", r#"{"id":"tool-1","name":"Tool"}"#),
+            ("default/manifest/skills.yml", "skills:\n  - id: skill-1\n    name: Skill\n"),
+            ("default/skills/skill-1/SKILL.md", "---\nid: skill-1\nname: Skill\ntool_ids:\n  - tool-1\n---\nInstructions\n"),
+            ("default/skills/skill-1/aaa/query.md", "Query body\n"),
+            ("default/skills/skill-1/zzz/intro.md", "Intro body\n"),
+            ("default/skills/skill-1/.referenced_content.yml", "entries:\n  - path: aaa/query.md\n    name: Query Reference\n    relativePath: ./references\n  - path: zzz/intro.md\n    name: Intro Reference\n    relativePath: ./examples\n"),
+        ]
+        .into_iter()
+        .map(|(path, content)| (path.to_string(), content.as_bytes().to_vec()))
+        .collect()
+    }
+
+    fn write_entries(root: &Path, entries: &[(String, Vec<u8>)]) {
+        for (path, content) in entries {
+            let path = root.join(path);
+            std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+            std::fs::write(path, content).unwrap();
+        }
+    }
+
+    #[test]
+    fn entry_sources_support_owned_borrowed_and_shared_bytes() {
+        let owned = KibanaBundle::from_entries(fixture())
+            .unwrap()
+            .read_all()
+            .unwrap();
+        let fixture = fixture();
+        let borrowed = KibanaBundle::from_entries(
+            fixture
+                .iter()
+                .map(|(path, content)| (path, content.as_slice())),
+        )
+        .unwrap()
+        .read_all()
+        .unwrap();
+        let shared = KibanaBundle::from_entries(
+            fixture
+                .iter()
+                .map(|(path, content)| (path, Arc::<[u8]>::from(content.clone()))),
+        )
+        .unwrap()
+        .read_all()
+        .unwrap();
+
+        assert_eq!(owned, borrowed);
+        assert_eq!(owned, shared);
+        let referenced = owned.by_space["default"].skills[0]["referenced_content"]
+            .as_array()
+            .unwrap();
+        assert_eq!(referenced[0]["name"], "Intro Reference");
+        assert_eq!(referenced[0]["relativePath"], "./examples");
+        assert_eq!(referenced[1]["name"], "Query Reference");
+        assert_eq!(referenced[1]["relativePath"], "./references");
+
+        let application = KibanaBundle::from_entries(
+            fixture
+                .iter()
+                .map(|(path, content)| (path, ApplicationBytes(content.clone()))),
+        )
+        .unwrap()
+        .read_all()
+        .unwrap();
+        assert_eq!(owned, application);
+    }
+
+    #[test]
+    fn filesystem_and_entries_have_read_parity() {
+        let temp = TempDir::new().unwrap();
+        let entries = fixture();
+        write_entries(temp.path(), &entries);
+
+        let filesystem = KibanaBundle::open(temp.path()).unwrap().read_all().unwrap();
+        let memory = KibanaBundle::from_entries(
+            entries
+                .iter()
+                .map(|(path, content)| (path, content.as_slice())),
+        )
+        .unwrap()
+        .read_all()
+        .unwrap();
+
+        assert_eq!(filesystem, memory);
+    }
+
+    #[test]
+    fn space_definitions_preserve_full_space_configuration() {
+        let bundle = KibanaBundle::from_entries([
+            (
+                "spaces.yml",
+                b"spaces:\n  - id: default\n    name: Default\n".as_slice(),
+            ),
+            (
+                "default/space.json",
+                br#"{id: "default", name: "Default", description: "Full definition", solution: "oblt"}"#
+                    .as_slice(),
+            ),
+        ])
+        .unwrap()
+        .read_all()
+        .unwrap();
+
+        assert_eq!(bundle.spaces[0]["description"], "Full definition");
+        assert_eq!(bundle.spaces[0]["solution"], "oblt");
+    }
+
+    #[test]
+    fn entry_paths_are_validated_and_directories_are_implicit() {
+        for path in [
+            "",
+            "/absolute.json",
+            "../escape.json",
+            "a/../b.json",
+            "C:\\root.json",
+            "dir/",
+        ] {
+            let result = KibanaBundle::from_entries([(path, b"{}".as_slice())]);
+            assert!(result.is_err(), "{path} should be invalid");
+        }
+
+        let duplicate = KibanaBundle::from_entries([
+            ("default/tools/tool.json", b"{}".as_slice()),
+            ("default\\tools\\tool.json", b"{}".as_slice()),
+        ]);
+        assert!(duplicate.unwrap_err().to_string().contains("duplicate"));
+
+        for entries in [
+            [
+                ("default/tools", b"{}".as_slice()),
+                ("default/tools/tool.json", b"{}".as_slice()),
+            ],
+            [
+                ("default/tools/tool.json", b"{}".as_slice()),
+                ("default/tools", b"{}".as_slice()),
+            ],
+        ] {
+            let collision = KibanaBundle::from_entries(entries).unwrap_err();
+            assert!(collision.to_string().contains("conflicts"));
+        }
+
+        let bundle = KibanaBundle::from_entries([(
+            "default/tools/tool.json",
+            br#"{"id":"tool-1"}"#.as_slice(),
+        )])
+        .unwrap();
+        assert!(bundle.source.is_dir(Path::new("default/tools")));
+        assert_eq!(
+            bundle
+                .source
+                .files_under(Path::new("default"))
+                .unwrap()
+                .len(),
+            1
+        );
+    }
+
+    #[test]
+    fn entry_errors_include_logical_paths() {
+        let invalid_utf8 = KibanaBundle::from_entries([("spaces.yml", [0xff])])
+            .unwrap()
+            .read_all()
+            .unwrap_err();
+        assert!(invalid_utf8.to_string().contains("spaces.yml"));
+
+        let invalid_json =
+            KibanaBundle::from_entries([("default/objects/bad.json", b"{".as_slice())])
+                .unwrap()
+                .read_all()
+                .unwrap_err();
+        assert!(
+            invalid_json
+                .to_string()
+                .contains("default/objects/bad.json")
+        );
+    }
+
+    #[test]
+    fn selection_and_manifest_order_match_filesystem_behavior() {
+        let mut entries = fixture();
+        entries
+            .iter_mut()
+            .find(|(path, _)| path == "default/manifest/tools.yml")
+            .unwrap()
+            .1 = b"tools:\n  - tool-2\n  - tool-1\n".to_vec();
+        entries.push((
+            "default/tools/z-tool-2.json".to_string(),
+            br#"{"id":"tool-2","name":"Tool Two"}"#.to_vec(),
+        ));
+        entries.push((
+            "default/tools/extra.json".to_string(),
+            br#"{"id":"extra"}"#.to_vec(),
+        ));
+        entries.push((
+            "secondary/tools/tool.json".to_string(),
+            br#"{"id":"secondary-tool"}"#.to_vec(),
+        ));
+        let temp = TempDir::new().unwrap();
+        write_entries(temp.path(), &entries);
+        let bundle = KibanaBundle::from_entries(entries).unwrap();
+        let selection = SyncSelection {
+            spaces: vec!["default".to_string()],
+            include_tools: true,
+            ..SyncSelection::default()
+        };
+        let read = bundle.read(&selection).unwrap();
+        let filesystem = KibanaBundle::open(temp.path())
+            .unwrap()
+            .read(&selection)
+            .unwrap();
+
+        assert_eq!(
+            read.by_space["default"].tools,
+            vec![
+                json!({"id": "tool-2", "name": "Tool Two"}),
+                json!({"id": "tool-1", "name": "Tool"}),
+            ]
+        );
+        assert!(read.by_space["default"].agents.is_empty());
+        assert!(!read.by_space.contains_key("secondary"));
+        assert_eq!(read, filesystem);
+    }
+
+    #[test]
+    fn empty_bundle_and_implicit_spaces_are_supported() {
+        let empty =
+            KibanaBundle::<Entries<&[u8]>>::from_entries(std::iter::empty::<(&str, &[u8])>())
+                .unwrap()
+                .read_all()
+                .unwrap();
+        assert!(empty.spaces.is_empty());
+        assert!(empty.by_space.is_empty());
+
+        let discovered = KibanaBundle::from_entries([
+            (
+                "spaces.yml",
+                b"spaces:\n  - id: listed\n    name: Listed\n".as_slice(),
+            ),
+            ("unlisted/tools/tool.json", br#"{"id":"tool-1"}"#.as_slice()),
+        ])
+        .unwrap()
+        .read_all()
+        .unwrap();
+        assert!(discovered.by_space.contains_key("listed"));
+        assert!(discovered.by_space.contains_key("unlisted"));
+    }
+
+    #[test]
+    fn missing_manifest_resources_report_logical_directory() {
+        let entries = vec![
+            (
+                "default/manifest/tools.yml".to_string(),
+                b"tools:\n  - missing-tool\n".to_vec(),
+            ),
+            (
+                "default/tools/present.json".to_string(),
+                br#"{"id":"present-tool"}"#.to_vec(),
+            ),
+        ];
+        let error = KibanaBundle::from_entries(entries.clone())
+            .unwrap()
+            .read_all()
+            .unwrap_err();
+
+        let temp = TempDir::new().unwrap();
+        write_entries(temp.path(), &entries);
+        let filesystem_error = KibanaBundle::open(temp.path())
+            .unwrap()
+            .read_all()
+            .unwrap_err();
+
+        assert!(error.to_string().contains("missing-tool"));
+        assert!(error.to_string().contains("default/tools"));
+        assert!(filesystem_error.to_string().contains("missing-tool"));
+        assert!(filesystem_error.to_string().contains("default/tools"));
+    }
+
+    #[test]
+    fn filesystem_write_round_trips_through_generic_reader() {
+        let temp = TempDir::new().unwrap();
+        let expected = KibanaBundle::from_entries(fixture())
+            .unwrap()
+            .read_all()
+            .unwrap();
+        let filesystem = KibanaBundle::create(temp.path()).unwrap();
+
+        filesystem.write(&expected).unwrap();
+        let actual = KibanaBundle::open(temp.path()).unwrap().read_all().unwrap();
+
+        assert_eq!(actual, expected);
+        assert_eq!(filesystem.root(), temp.path());
+    }
+}

--- a/crates/kibana-sync/src/bundle.rs
+++ b/crates/kibana-sync/src/bundle.rs
@@ -117,13 +117,13 @@ impl<B: AsRef<[u8]>> KibanaBundle<Entries<B>> {
             if directories.contains(&normalized) {
                 return Err(Error::message(format!(
                     "bundle entry path conflicts with an implicit directory: {}",
-                    normalized.display()
+                    logical_path(&normalized)
                 )));
             }
             if files.insert(normalized.clone(), content).is_some() {
                 return Err(Error::message(format!(
                     "duplicate bundle entry path: {}",
-                    normalized.display()
+                    logical_path(&normalized)
                 )));
             }
 
@@ -135,7 +135,7 @@ impl<B: AsRef<[u8]>> KibanaBundle<Entries<B>> {
                 if files.contains_key(directory) {
                     return Err(Error::message(format!(
                         "bundle entry path conflicts with a file: {}",
-                        directory.display()
+                        logical_path(directory)
                     )));
                 }
                 directories.insert(directory.to_path_buf());
@@ -388,20 +388,22 @@ impl<S: BundleSource> KibanaBundle<S> {
             )
         })?;
         let text = utf8(content.as_ref(), &self.source.display_path(&path))?;
-        let definition = json5::from_json5_str(text).with_context(|| {
+        let mut definition = json5::from_json5_str(text).with_context(|| {
             format!(
                 "Failed to parse space definition: {}",
                 self.source.display_path(&path)
             )
         })?;
         let id = definition.get("id").and_then(Value::as_str);
-        let name = definition.get("name").and_then(Value::as_str);
-        if id != Some(space.id.as_str()) || name.is_none() {
+        if id != Some(space.id.as_str()) {
             return Err(Error::message(format!(
-                "space definition {} must contain the manifest id '{}' and a name",
+                "space definition {} must contain the manifest id '{}'",
                 self.source.display_path(&path),
                 space.id
             )));
+        }
+        if definition.get("name").and_then(Value::as_str).is_none() {
+            definition["name"] = Value::String(space.name.clone());
         }
         Ok(definition)
     }
@@ -609,7 +611,10 @@ impl<B: AsRef<[u8]>> BundleSource for Entries<B> {
 
     fn read(&self, path: &Path) -> Result<Self::Content<'_>> {
         self.files.get(path).ok_or_else(|| {
-            Error::message(format!("bundle entry does not exist: {}", path.display()))
+            Error::message(format!(
+                "bundle entry does not exist: {}",
+                self.display_path(path)
+            ))
         })
     }
 
@@ -672,6 +677,10 @@ fn normalize_entry_path(path: &Path) -> Result<PathBuf> {
         )));
     }
     Ok(normalized)
+}
+
+fn logical_path(path: &Path) -> String {
+    path.to_string_lossy().replace('\\', "/")
 }
 
 fn collect_files(root: &Path, directory: &Path, files: &mut Vec<PathBuf>) -> Result<()> {
@@ -905,6 +914,26 @@ mod tests {
         .unwrap();
 
         assert_eq!(bundle.spaces[0]["description"], "Full definition");
+        assert_eq!(bundle.spaces[0]["solution"], "oblt");
+    }
+
+    #[test]
+    fn space_definitions_default_missing_name_from_manifest() {
+        let bundle = KibanaBundle::from_entries([
+            (
+                "spaces.yml",
+                b"spaces:\n  - id: default\n    name: Default\n".as_slice(),
+            ),
+            (
+                "default/space.json",
+                br#"{id: "default", solution: "oblt"}"#.as_slice(),
+            ),
+        ])
+        .unwrap()
+        .read_all()
+        .unwrap();
+
+        assert_eq!(bundle.spaces[0]["name"], "Default");
         assert_eq!(bundle.spaces[0]["solution"], "oblt");
     }
 

--- a/crates/kibana-sync/src/fs.rs
+++ b/crates/kibana-sync/src/fs.rs
@@ -1,5 +1,6 @@
 //! Filesystem writer for the stable Kibana bundle layout.
 
+use crate::bundle::validate_space_id;
 use crate::kibana::agents::{AgentEntry, AgentsManifest};
 use crate::kibana::saved_objects::{SavedObject, SavedObjectsManifest};
 use crate::kibana::skills::{SkillEntry, SkillsManifest, skill_to_directory};
@@ -37,6 +38,7 @@ impl FilesystemWriter {
     }
 
     fn write_space_bundle(&self, space_id: &str, bundle: &SpaceBundle) -> Result<()> {
+        validate_space_id(space_id)?;
         let manifest_dir = self.manifest_dir(space_id);
 
         if !bundle.saved_objects.is_empty() {
@@ -86,6 +88,7 @@ impl FilesystemWriter {
                 return Err(Error::message("space must be a JSON object"));
             }
             let id = required_str(space, "id", "space")?;
+            validate_space_id(id)?;
             let name = optional_str(space, "name").unwrap_or(id);
             entries.push(SpaceEntry::new(id.to_string(), name.to_string()));
         }

--- a/crates/kibana-sync/src/fs.rs
+++ b/crates/kibana-sync/src/fs.rs
@@ -1,142 +1,38 @@
-//! Explicit filesystem bundle support for Kibana sync resources.
-//!
-//! These helpers operate only on caller-provided paths. They do not discover
-//! project roots, read environment variables, initialize logging, or apply CLI
-//! migration policy.
+//! Filesystem writer for the stable Kibana bundle layout.
 
 use crate::kibana::agents::{AgentEntry, AgentsManifest};
 use crate::kibana::saved_objects::{SavedObject, SavedObjectsManifest};
-use crate::kibana::skills::{SkillEntry, SkillsManifest, skill_to_directory, skill_to_value};
+use crate::kibana::skills::{SkillEntry, SkillsManifest, skill_to_directory};
 use crate::kibana::spaces::{SpaceEntry, SpacesManifest};
 use crate::kibana::tools::ToolsManifest;
 use crate::kibana::workflows::{WorkflowEntry, WorkflowsManifest};
-use crate::sync::{SpaceBundle, SyncBundle, SyncSelection};
-use crate::{Error, Result, ResultContext, json5};
+use crate::sync::{SpaceBundle, SyncBundle};
+use crate::{Error, Result, ResultContext};
 use serde_json::Value;
-use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
-#[cfg(test)]
-use crate::kibana::skills::skill_directory_name;
-
-/// Path-explicit reader and writer for version-controlled Kibana asset bundles.
-///
-/// The stable layout is:
-///
-/// ```text
-/// <root>/
-///   spaces.yml
-///   <space>/
-///     manifest/
-///       saved_objects.json
-///       workflows.yml
-///       agents.yml
-///       tools.yml
-///     objects/
-///     workflows/
-///     agents/
-///     tools/
-///     skills/
-/// ```
-#[derive(Clone, Debug)]
-pub struct KibanaFsBundle {
+pub(crate) struct FilesystemWriter {
     root: PathBuf,
 }
 
-impl KibanaFsBundle {
-    /// Reference a filesystem bundle rooted at a caller-provided path.
-    pub fn open(root: impl AsRef<Path>) -> Result<Self> {
-        let root = root.as_ref().to_path_buf();
-        if !root.exists() {
-            return Err(Error::message(format!(
-                "filesystem bundle root does not exist: {}",
-                root.display()
-            )));
-        }
-
-        Ok(Self { root })
-    }
-
-    /// Create or reference a filesystem bundle rooted at a caller-provided path.
-    pub fn create(root: impl AsRef<Path>) -> Result<Self> {
+impl FilesystemWriter {
+    pub(crate) fn create(root: impl AsRef<Path>) -> Result<Self> {
         let root = root.as_ref().to_path_buf();
         std::fs::create_dir_all(&root)
             .with_context(|| format!("Failed to create bundle root: {}", root.display()))?;
         Ok(Self { root })
     }
 
-    /// Return the caller-provided bundle root.
-    pub fn root(&self) -> &Path {
-        &self.root
-    }
-
-    /// Read all resource families discoverable in the bundle.
-    pub fn read_all(&self) -> Result<SyncBundle> {
-        let spaces = self.discover_space_ids()?;
-        let selection = SyncSelection {
-            spaces,
-            saved_objects: Some(SavedObjectsManifest::new()),
-            include_spaces: self.spaces_manifest_path().exists(),
-            include_workflows: true,
-            include_agents: true,
-            include_tools: true,
-            include_skills: true,
-        };
-
-        self.read(&selection)
-    }
-
-    /// Read selected resource families into a storage-neutral sync bundle.
-    pub fn read(&self, selection: &SyncSelection) -> Result<SyncBundle> {
-        let mut bundle = SyncBundle::default();
-
-        if selection.include_spaces {
-            bundle.spaces = self.read_spaces()?;
-        }
-
-        for space_id in &selection.spaces {
-            let mut space_bundle = SpaceBundle::default();
-
-            if let Some(selection_manifest) = &selection.saved_objects {
-                space_bundle.saved_objects =
-                    self.read_saved_objects(space_id, selection_manifest)?;
-            }
-
-            if selection.include_workflows {
-                space_bundle.workflows = self.read_workflows(space_id)?;
-            }
-
-            if selection.include_agents {
-                space_bundle.agents = self.read_agents(space_id)?;
-            }
-
-            if selection.include_tools {
-                space_bundle.tools = self.read_tools(space_id)?;
-            }
-
-            if selection.include_skills {
-                space_bundle.skills = self.read_skills(space_id)?;
-            }
-
-            bundle.by_space.insert(space_id.clone(), space_bundle);
-        }
-
-        Ok(bundle)
-    }
-
-    /// Write a storage-neutral sync bundle to the stable filesystem layout.
-    pub fn write(&self, bundle: &SyncBundle) -> Result<()> {
+    pub(crate) fn write(&self, bundle: &SyncBundle) -> Result<()> {
         std::fs::create_dir_all(&self.root)
             .with_context(|| format!("Failed to create bundle root: {}", self.root.display()))?;
 
         if !bundle.spaces.is_empty() {
             self.write_spaces(&bundle.spaces)?;
         }
-
         for (space_id, space_bundle) in &bundle.by_space {
             self.write_space_bundle(space_id, space_bundle)?;
         }
-
         Ok(())
     }
 
@@ -144,393 +40,67 @@ impl KibanaFsBundle {
         let manifest_dir = self.manifest_dir(space_id);
 
         if !bundle.saved_objects.is_empty() {
-            let manifest = saved_objects_manifest(&bundle.saved_objects)?;
-            manifest.write(manifest_dir.join("saved_objects.json"))?;
+            saved_objects_manifest(&bundle.saved_objects)?
+                .write(manifest_dir.join("saved_objects.json"))?;
             write_json_values(
-                &self.objects_dir(space_id),
+                &self.resource_dir(space_id, "objects"),
                 &bundle.saved_objects,
                 saved_object_relative_path,
             )?;
         }
-
         if !bundle.workflows.is_empty() {
-            let manifest = workflows_manifest(&bundle.workflows)?;
-            manifest.write(manifest_dir.join("workflows.yml"))?;
+            workflows_manifest(&bundle.workflows)?.write(manifest_dir.join("workflows.yml"))?;
             write_json_values(
-                &self.workflows_dir(space_id),
+                &self.resource_dir(space_id, "workflows"),
                 &bundle.workflows,
                 workflow_resource_file_name,
             )?;
         }
-
         if !bundle.agents.is_empty() {
-            let manifest = agents_manifest(&bundle.agents)?;
-            manifest.write(manifest_dir.join("agents.yml"))?;
+            agents_manifest(&bundle.agents)?.write(manifest_dir.join("agents.yml"))?;
             write_json_values(
-                &self.agents_dir(space_id),
+                &self.resource_dir(space_id, "agents"),
                 &bundle.agents,
                 named_resource_file_name,
             )?;
         }
-
         if !bundle.tools.is_empty() {
-            let manifest = tools_manifest(&bundle.tools)?;
-            manifest.write(manifest_dir.join("tools.yml"))?;
+            tools_manifest(&bundle.tools)?.write(manifest_dir.join("tools.yml"))?;
             write_json_values(
-                &self.tools_dir(space_id),
+                &self.resource_dir(space_id, "tools"),
                 &bundle.tools,
                 named_resource_file_name,
             )?;
         }
-
         if !bundle.skills.is_empty() {
-            let manifest = skills_manifest(&bundle.skills)?;
-            manifest.write(manifest_dir.join("skills.yml"))?;
-            write_skill_directories(&self.skills_dir(space_id), &bundle.skills)?;
+            skills_manifest(&bundle.skills)?.write(manifest_dir.join("skills.yml"))?;
+            write_skill_directories(&self.resource_dir(space_id, "skills"), &bundle.skills)?;
         }
-
         Ok(())
-    }
-
-    fn read_saved_objects(
-        &self,
-        space_id: &str,
-        selection_manifest: &SavedObjectsManifest,
-    ) -> Result<Vec<Value>> {
-        let values = read_json_dir(&self.objects_dir(space_id))?;
-        let manifest_path = self.saved_objects_manifest_path(space_id);
-
-        let manifest = if manifest_path.exists() {
-            Some(SavedObjectsManifest::read(manifest_path)?)
-        } else if selection_manifest.objects.is_empty() {
-            None
-        } else {
-            Some(selection_manifest.clone())
-        };
-
-        let Some(manifest) = manifest else {
-            return Ok(values);
-        };
-
-        manifest
-            .objects
-            .iter()
-            .map(|object| {
-                values
-                    .iter()
-                    .find(|value| saved_object_matches(value, &object.object_type, &object.id))
-                    .cloned()
-                    .ok_or_else(|| {
-                        missing_manifest_resource(
-                            "saved object",
-                            format!("{}/{}", object.object_type, object.id),
-                            &self.objects_dir(space_id),
-                        )
-                    })
-            })
-            .collect()
-    }
-
-    fn read_workflows(&self, space_id: &str) -> Result<Vec<Value>> {
-        let values = read_json_dir(&self.workflows_dir(space_id))?;
-        let manifest_path = self.workflows_manifest_path(space_id);
-        if !manifest_path.exists() {
-            return Ok(values);
-        }
-
-        let manifest = WorkflowsManifest::read(manifest_path)?;
-        manifest
-            .workflows
-            .iter()
-            .map(|entry| {
-                find_named_resource(&values, &entry.id, Some(&entry.name)).ok_or_else(|| {
-                    missing_manifest_resource("workflow", &entry.id, &self.workflows_dir(space_id))
-                })
-            })
-            .collect()
-    }
-
-    fn read_agents(&self, space_id: &str) -> Result<Vec<Value>> {
-        let values = read_json_dir(&self.agents_dir(space_id))?;
-        let manifest_path = self.agents_manifest_path(space_id);
-        if !manifest_path.exists() {
-            return Ok(values);
-        }
-
-        let manifest = AgentsManifest::read(manifest_path)?;
-        manifest
-            .agents
-            .iter()
-            .map(|entry| {
-                find_named_resource(&values, &entry.id, Some(&entry.name)).ok_or_else(|| {
-                    missing_manifest_resource("agent", &entry.id, &self.agents_dir(space_id))
-                })
-            })
-            .collect()
-    }
-
-    fn read_tools(&self, space_id: &str) -> Result<Vec<Value>> {
-        let values = read_json_dir(&self.tools_dir(space_id))?;
-        let manifest_path = self.tools_manifest_path(space_id);
-        if !manifest_path.exists() {
-            return Ok(values);
-        }
-
-        let manifest = ToolsManifest::read(manifest_path)?;
-        manifest
-            .tools
-            .iter()
-            .map(|tool_id| {
-                find_named_resource(&values, tool_id, None).ok_or_else(|| {
-                    missing_manifest_resource("tool", tool_id, &self.tools_dir(space_id))
-                })
-            })
-            .collect()
-    }
-
-    fn read_skills(&self, space_id: &str) -> Result<Vec<Value>> {
-        let root = self.skills_dir(space_id);
-        let manifest_path = self.skills_manifest_path(space_id);
-        let manifest = if manifest_path.exists() {
-            Some(SkillsManifest::read(manifest_path)?)
-        } else {
-            None
-        };
-
-        if !root.exists() {
-            if let Some(manifest) = manifest
-                && let Some(entry) = manifest.skills.first()
-            {
-                return Err(missing_skill_manifest_resource(&entry.id, &root));
-            }
-            return Ok(Vec::new());
-        }
-
-        let mut directories = Vec::new();
-        for entry in std::fs::read_dir(&root)? {
-            let entry = entry?;
-            let path = entry.path();
-            let metadata = std::fs::symlink_metadata(&path)?;
-            if metadata.file_type().is_symlink() {
-                return Err(Error::message(format!(
-                    "skill directory cannot be a symlink: {}",
-                    path.display()
-                )));
-            }
-            if metadata.is_dir() && path.join("SKILL.md").exists() {
-                directories.push(path);
-            }
-        }
-        directories.sort();
-
-        let values = directories
-            .into_iter()
-            .map(|directory| skill_to_value(&directory, true))
-            .collect::<Result<Vec<_>>>()?;
-
-        let Some(manifest) = manifest else {
-            return Ok(values);
-        };
-        manifest
-            .skills
-            .iter()
-            .map(|entry| {
-                values
-                    .iter()
-                    .find(|value| value.get("id").and_then(|id| id.as_str()) == Some(&entry.id))
-                    .cloned()
-                    .ok_or_else(|| missing_skill_manifest_resource(&entry.id, &root))
-            })
-            .collect()
-    }
-
-    fn read_spaces(&self) -> Result<Vec<Value>> {
-        let path = self.spaces_manifest_path();
-        if !path.exists() {
-            return Ok(Vec::new());
-        }
-
-        let manifest = SpacesManifest::read(path)?;
-        Ok(manifest
-            .spaces
-            .into_iter()
-            .map(|space| serde_json::json!({"id": space.id, "name": space.name}))
-            .collect())
     }
 
     fn write_spaces(&self, spaces: &[Value]) -> Result<()> {
         let mut entries = Vec::with_capacity(spaces.len());
-
         for space in spaces {
             let id = required_str(space, "id", "space")?;
             let name = optional_str(space, "name").unwrap_or(id);
             entries.push(SpaceEntry::new(id.to_string(), name.to_string()));
         }
-
-        SpacesManifest::with_spaces(entries).write(self.spaces_manifest_path())
-    }
-
-    fn discover_space_ids(&self) -> Result<Vec<String>> {
-        let mut ids = BTreeSet::new();
-
-        let spaces_path = self.spaces_manifest_path();
-        if spaces_path.exists() {
-            let manifest = SpacesManifest::read(spaces_path)?;
-            ids.extend(manifest.spaces.into_iter().map(|space| space.id));
+        SpacesManifest::with_spaces(entries).write(self.root.join("spaces.yml"))?;
+        for space in spaces {
+            let id = required_str(space, "id", "space")?;
+            write_json_file(&self.root.join(id).join("space.json"), space)?;
         }
-
-        if self.root.exists() {
-            for entry in std::fs::read_dir(&self.root)? {
-                let entry = entry?;
-                let path = entry.path();
-                if !path.is_dir() {
-                    continue;
-                }
-
-                let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
-                    continue;
-                };
-
-                if self.has_space_resources(name) {
-                    ids.insert(name.to_string());
-                }
-            }
-        }
-
-        Ok(ids.into_iter().collect())
-    }
-
-    fn has_space_resources(&self, space_id: &str) -> bool {
-        self.objects_dir(space_id).exists()
-            || self.workflows_dir(space_id).exists()
-            || self.agents_dir(space_id).exists()
-            || self.tools_dir(space_id).exists()
-            || self.skills_dir(space_id).exists()
-            || self.manifest_dir(space_id).exists()
-    }
-
-    fn spaces_manifest_path(&self) -> PathBuf {
-        self.root.join("spaces.yml")
-    }
-
-    fn space_dir(&self, space_id: &str) -> PathBuf {
-        self.root.join(space_id)
+        Ok(())
     }
 
     fn manifest_dir(&self, space_id: &str) -> PathBuf {
-        self.space_dir(space_id).join("manifest")
+        self.root.join(space_id).join("manifest")
     }
 
-    fn saved_objects_manifest_path(&self, space_id: &str) -> PathBuf {
-        self.manifest_dir(space_id).join("saved_objects.json")
+    fn resource_dir(&self, space_id: &str, resource: &str) -> PathBuf {
+        self.root.join(space_id).join(resource)
     }
-
-    fn workflows_manifest_path(&self, space_id: &str) -> PathBuf {
-        self.manifest_dir(space_id).join("workflows.yml")
-    }
-
-    fn agents_manifest_path(&self, space_id: &str) -> PathBuf {
-        self.manifest_dir(space_id).join("agents.yml")
-    }
-
-    fn tools_manifest_path(&self, space_id: &str) -> PathBuf {
-        self.manifest_dir(space_id).join("tools.yml")
-    }
-
-    fn skills_manifest_path(&self, space_id: &str) -> PathBuf {
-        self.manifest_dir(space_id).join("skills.yml")
-    }
-
-    fn objects_dir(&self, space_id: &str) -> PathBuf {
-        self.space_dir(space_id).join("objects")
-    }
-
-    fn workflows_dir(&self, space_id: &str) -> PathBuf {
-        self.space_dir(space_id).join("workflows")
-    }
-
-    fn agents_dir(&self, space_id: &str) -> PathBuf {
-        self.space_dir(space_id).join("agents")
-    }
-
-    fn tools_dir(&self, space_id: &str) -> PathBuf {
-        self.space_dir(space_id).join("tools")
-    }
-
-    fn skills_dir(&self, space_id: &str) -> PathBuf {
-        self.space_dir(space_id).join("skills")
-    }
-}
-
-fn read_json_dir(path: &Path) -> Result<Vec<Value>> {
-    if !path.exists() {
-        return Ok(Vec::new());
-    }
-
-    let mut files = Vec::new();
-    collect_json_files(path, &mut files)?;
-    files.sort();
-
-    files
-        .into_iter()
-        .map(|file| {
-            let content = std::fs::read_to_string(&file)
-                .with_context(|| format!("Failed to read JSON resource: {}", file.display()))?;
-            json5::from_json5_str(&content)
-                .with_context(|| format!("Failed to parse JSON resource: {}", file.display()))
-        })
-        .collect()
-}
-
-fn collect_json_files(path: &Path, files: &mut Vec<PathBuf>) -> Result<()> {
-    for entry in std::fs::read_dir(path)? {
-        let entry = entry?;
-        let path = entry.path();
-        if path.is_dir() {
-            collect_json_files(&path, files)?;
-        } else if path.extension().and_then(|extension| extension.to_str()) == Some("json") {
-            files.push(path);
-        }
-    }
-
-    Ok(())
-}
-
-fn saved_object_matches(value: &Value, object_type: &str, id: &str) -> bool {
-    value.get("type").and_then(|field| field.as_str()) == Some(object_type)
-        && value.get("id").and_then(|field| field.as_str()) == Some(id)
-}
-
-fn find_named_resource(values: &[Value], id: &str, name: Option<&str>) -> Option<Value> {
-    values
-        .iter()
-        .find(|value| value.get("id").and_then(|field| field.as_str()) == Some(id))
-        .or_else(|| {
-            name.and_then(|name| {
-                values
-                    .iter()
-                    .find(|value| value.get("name").and_then(|field| field.as_str()) == Some(name))
-            })
-        })
-        .cloned()
-}
-
-fn missing_manifest_resource(
-    resource: &str,
-    id: impl std::fmt::Display,
-    directory: &Path,
-) -> Error {
-    Error::message(format!(
-        "{resource} '{id}' is listed in the manifest but no matching JSON resource was found under {}",
-        directory.display()
-    ))
-}
-
-fn missing_skill_manifest_resource(id: impl std::fmt::Display, directory: &Path) -> Error {
-    Error::message(format!(
-        "skill '{id}' is listed in the manifest but no matching skills/<skill-directory>/SKILL.md resource was found under {}",
-        directory.display()
-    ))
 }
 
 fn write_json_values(
@@ -539,10 +109,8 @@ fn write_json_values(
     relative_path: fn(&Value) -> Result<PathBuf>,
 ) -> Result<()> {
     for value in values {
-        let path = root.join(relative_path(value)?);
-        write_json_file(&path, value)?;
+        write_json_file(&root.join(relative_path(value)?), value)?;
     }
-
     Ok(())
 }
 
@@ -551,7 +119,6 @@ fn write_json_file(path: &Path, value: &Value) -> Result<()> {
         std::fs::create_dir_all(parent)
             .with_context(|| format!("Failed to create directory: {}", parent.display()))?;
     }
-
     let json = serde_json::to_string_pretty(value)
         .with_context(|| format!("Failed to serialize JSON resource: {}", path.display()))?;
     std::fs::write(path, json)
@@ -568,7 +135,6 @@ fn write_skill_directories(root: &Path, values: &[Value]) -> Result<()> {
 fn saved_object_relative_path(value: &Value) -> Result<PathBuf> {
     let object_type = required_str(value, "type", "saved object")?;
     let id = required_str(value, "id", "saved object")?;
-
     Ok(PathBuf::from(sanitize_path_component(object_type))
         .join(format!("{}.json", sanitize_path_component(id))))
 }
@@ -585,7 +151,6 @@ fn named_resource_file_name(value: &Value) -> Result<PathBuf> {
             )
         })
         .unwrap_or_else(|| sanitize_path_component(id));
-
     Ok(PathBuf::from(format!("{stem}.json")))
 }
 
@@ -601,7 +166,6 @@ fn workflow_resource_file_name(value: &Value) -> Result<PathBuf> {
             )
         })
         .unwrap_or_else(|| sanitize_workflow_file_stem(id));
-
     Ok(PathBuf::from(format!("{stem}.json")))
 }
 
@@ -621,8 +185,10 @@ fn workflows_manifest(values: &[Value]) -> Result<WorkflowsManifest> {
     let mut entries = Vec::with_capacity(values.len());
     for value in values {
         let id = required_str(value, "id", "workflow")?;
-        let name = optional_str(value, "name").unwrap_or(id);
-        entries.push(WorkflowEntry::new(id, name));
+        entries.push(WorkflowEntry::new(
+            id,
+            optional_str(value, "name").unwrap_or(id),
+        ));
     }
     Ok(WorkflowsManifest::with_workflows(entries))
 }
@@ -631,17 +197,19 @@ fn agents_manifest(values: &[Value]) -> Result<AgentsManifest> {
     let mut entries = Vec::with_capacity(values.len());
     for value in values {
         let id = required_str(value, "id", "agent")?;
-        let name = optional_str(value, "name").unwrap_or(id);
-        entries.push(AgentEntry::new(id, name));
+        entries.push(AgentEntry::new(
+            id,
+            optional_str(value, "name").unwrap_or(id),
+        ));
     }
     Ok(AgentsManifest::with_agents(entries))
 }
 
 fn tools_manifest(values: &[Value]) -> Result<ToolsManifest> {
-    let mut tools = Vec::with_capacity(values.len());
-    for value in values {
-        tools.push(required_str(value, "id", "tool")?.to_string());
-    }
+    let tools = values
+        .iter()
+        .map(|value| required_str(value, "id", "tool").map(ToOwned::to_owned))
+        .collect::<Result<Vec<_>>>()?;
     Ok(ToolsManifest::with_tools(tools))
 }
 
@@ -649,8 +217,10 @@ fn skills_manifest(values: &[Value]) -> Result<SkillsManifest> {
     let mut entries = Vec::with_capacity(values.len());
     for value in values {
         let id = required_str(value, "id", "skill")?;
-        let name = optional_str(value, "name").unwrap_or(id);
-        entries.push(SkillEntry::new(id, name));
+        entries.push(SkillEntry::new(
+            id,
+            optional_str(value, "name").unwrap_or(id),
+        ));
     }
     Ok(SkillsManifest::with_skills(entries))
 }
@@ -662,7 +232,7 @@ fn required_str<'a>(
 ) -> Result<&'a str> {
     value
         .get(field)
-        .and_then(|field| field.as_str())
+        .and_then(Value::as_str)
         .ok_or(if field == "id" {
             Error::MissingResourceId { resource }
         } else {
@@ -671,7 +241,7 @@ fn required_str<'a>(
 }
 
 fn optional_str<'a>(value: &'a Value, field: &str) -> Option<&'a str> {
-    value.get(field).and_then(|field| field.as_str())
+    value.get(field).and_then(Value::as_str)
 }
 
 fn sanitize_path_component(value: &str) -> String {
@@ -685,7 +255,6 @@ fn sanitize_path_component(value: &str) -> String {
         .collect::<String>()
         .trim()
         .to_string();
-
     if sanitized.is_empty() {
         "unnamed".to_string()
     } else {
@@ -694,487 +263,14 @@ fn sanitize_path_component(value: &str) -> String {
 }
 
 fn sanitize_workflow_file_stem(value: &str) -> String {
-    let sanitized = sanitize_path_component(value);
-    let stem = sanitized
+    let stem = sanitize_path_component(value)
         .split_whitespace()
         .collect::<Vec<_>>()
         .join("_")
         .to_lowercase();
-
     if stem.is_empty() {
         "unnamed".to_string()
     } else {
         stem
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::sync::{SpaceBundle, SyncBundle, SyncSelection};
-    use serde_json::json;
-    use tempfile::TempDir;
-
-    #[test]
-    fn round_trips_bundle_through_explicit_path() {
-        let temp = TempDir::new().unwrap();
-        let bundle_path = temp.path().join("bundle");
-
-        let mut bundle = SyncBundle {
-            spaces: vec![json!({"id": "default", "name": "Default"})],
-            ..SyncBundle::default()
-        };
-        bundle.by_space.insert(
-            "default".to_string(),
-            SpaceBundle {
-                saved_objects: vec![json!({
-                    "type": "dashboard",
-                    "id": "dashboard-1",
-                    "attributes": {"title": "Sales Dashboard"}
-                })],
-                workflows: vec![json!({"id": "workflow-1", "name": "Daily Workflow"})],
-                agents: vec![json!({"id": "agent-1", "name": "Support Agent"})],
-                tools: vec![json!({"id": "tool-1", "name": "Search Tool"})],
-                skills: vec![json!({
-                    "id": "skill-1",
-                    "name": "Skill One",
-                    "description": "Skill description",
-                    "content": "Main skill body\n",
-                    "tool_ids": ["tool-1"],
-                    "referenced_content": [
-                        {"name": "query", "relativePath": "./examples", "content": "from logs\n"}
-                    ]
-                })],
-            },
-        );
-
-        let writer = KibanaFsBundle::create(&bundle_path).unwrap();
-        writer.write(&bundle).unwrap();
-
-        assert!(bundle_path.join("spaces.yml").exists());
-        assert!(
-            bundle_path
-                .join("default/manifest/saved_objects.json")
-                .exists()
-        );
-        assert!(
-            bundle_path
-                .join("default/objects/dashboard/dashboard-1.json")
-                .exists()
-        );
-        assert!(
-            bundle_path
-                .join("default/workflows/daily_workflow--workflow-1.json")
-                .exists()
-        );
-        assert!(
-            bundle_path
-                .join("default/agents/Support Agent--agent-1.json")
-                .exists()
-        );
-        assert!(
-            bundle_path
-                .join("default/tools/Search Tool--tool-1.json")
-                .exists()
-        );
-        assert!(bundle_path.join("default/manifest/skills.yml").exists());
-        let skill_dir = skill_directory_name(&bundle.by_space["default"].skills[0]).unwrap();
-        assert!(
-            bundle_path
-                .join("default/skills")
-                .join(&skill_dir)
-                .join("SKILL.md")
-                .exists()
-        );
-        assert!(
-            bundle_path
-                .join("default/skills")
-                .join(&skill_dir)
-                .join("examples/query.md")
-                .exists()
-        );
-
-        let reader = KibanaFsBundle::open(&bundle_path).unwrap();
-        let read = reader.read_all().unwrap();
-
-        assert_eq!(read.spaces, bundle.spaces);
-        assert_eq!(
-            read.by_space["default"].saved_objects,
-            bundle.by_space["default"].saved_objects
-        );
-        assert_eq!(
-            read.by_space["default"].workflows,
-            bundle.by_space["default"].workflows
-        );
-        assert_eq!(
-            read.by_space["default"].agents,
-            bundle.by_space["default"].agents
-        );
-        assert_eq!(
-            read.by_space["default"].tools,
-            bundle.by_space["default"].tools
-        );
-        assert_eq!(
-            read.by_space["default"].skills,
-            bundle.by_space["default"].skills
-        );
-    }
-
-    #[test]
-    fn round_trips_skills_only_bundle() {
-        let temp = TempDir::new().unwrap();
-        let bundle_path = temp.path().join("bundle");
-
-        let mut bundle = SyncBundle::default();
-        bundle.by_space.insert(
-            "default".to_string(),
-            SpaceBundle {
-                skills: vec![json!({
-                    "id": "skill-only",
-                    "name": "Skill Only",
-                    "description": "Only skill resources",
-                    "content": "Main instructions\n",
-                    "tool_ids": [],
-                    "referenced_content": []
-                })],
-                ..SpaceBundle::default()
-            },
-        );
-
-        KibanaFsBundle::create(&bundle_path)
-            .unwrap()
-            .write(&bundle)
-            .unwrap();
-
-        let skill_dir = skill_directory_name(&bundle.by_space["default"].skills[0]).unwrap();
-        assert!(
-            bundle_path
-                .join("default/skills")
-                .join(&skill_dir)
-                .join("SKILL.md")
-                .exists()
-        );
-        assert!(bundle_path.join("default/manifest/skills.yml").exists());
-
-        let read = KibanaFsBundle::open(&bundle_path)
-            .unwrap()
-            .read_all()
-            .unwrap();
-
-        assert_eq!(
-            read.by_space["default"].skills,
-            bundle.by_space["default"].skills
-        );
-        assert!(read.by_space["default"].saved_objects.is_empty());
-        assert!(read.by_space["default"].workflows.is_empty());
-        assert!(read.by_space["default"].agents.is_empty());
-        assert!(read.by_space["default"].tools.is_empty());
-    }
-
-    #[test]
-    fn read_honors_explicit_selection() {
-        let temp = TempDir::new().unwrap();
-        let bundle_path = temp.path().join("bundle");
-        let fs_bundle = KibanaFsBundle::create(&bundle_path).unwrap();
-
-        let mut bundle = SyncBundle::default();
-        bundle.by_space.insert(
-            "marketing".to_string(),
-            SpaceBundle {
-                saved_objects: vec![json!({"type": "dashboard", "id": "dashboard-1"})],
-                workflows: vec![json!({"id": "workflow-1", "name": "Workflow"})],
-                agents: vec![json!({"id": "agent-1", "name": "Agent"})],
-                tools: vec![json!({"id": "tool-1", "name": "Tool"})],
-                skills: vec![json!({"id": "skill-1", "name": "Skill", "content": "Body\n"})],
-            },
-        );
-        fs_bundle.write(&bundle).unwrap();
-
-        let selection = SyncSelection {
-            spaces: vec!["marketing".to_string()],
-            saved_objects: None,
-            include_spaces: false,
-            include_workflows: true,
-            include_agents: false,
-            include_tools: true,
-            include_skills: true,
-        };
-
-        let read = KibanaFsBundle::open(&bundle_path)
-            .unwrap()
-            .read(&selection)
-            .unwrap();
-        let space = &read.by_space["marketing"];
-
-        assert!(space.saved_objects.is_empty());
-        assert_eq!(space.workflows.len(), 1);
-        assert!(space.agents.is_empty());
-        assert_eq!(space.tools.len(), 1);
-        assert_eq!(space.skills.len(), 1);
-    }
-
-    #[test]
-    fn read_uses_caller_provided_path_only() {
-        let temp = TempDir::new().unwrap();
-        let first_path = temp.path().join("first");
-        let second_path = temp.path().join("second");
-
-        let mut first = SyncBundle::default();
-        first.by_space.insert(
-            "default".to_string(),
-            SpaceBundle {
-                tools: vec![json!({"id": "first-tool"})],
-                ..SpaceBundle::default()
-            },
-        );
-        KibanaFsBundle::create(&first_path)
-            .unwrap()
-            .write(&first)
-            .unwrap();
-
-        let mut second = SyncBundle::default();
-        second.by_space.insert(
-            "default".to_string(),
-            SpaceBundle {
-                tools: vec![json!({"id": "second-tool"})],
-                ..SpaceBundle::default()
-            },
-        );
-        KibanaFsBundle::create(&second_path)
-            .unwrap()
-            .write(&second)
-            .unwrap();
-
-        let selection = SyncSelection {
-            spaces: vec!["default".to_string()],
-            include_tools: true,
-            ..SyncSelection::default()
-        };
-        let read = KibanaFsBundle::open(&second_path)
-            .unwrap()
-            .read(&selection)
-            .unwrap();
-
-        assert_eq!(read.by_space["default"].tools[0]["id"], "second-tool");
-    }
-
-    #[test]
-    fn read_uses_per_space_manifests_as_source_of_truth() {
-        let temp = TempDir::new().unwrap();
-        let bundle_path = temp.path().join("bundle");
-        let fs_bundle = KibanaFsBundle::create(&bundle_path).unwrap();
-
-        let mut bundle = SyncBundle::default();
-        bundle.by_space.insert(
-            "default".to_string(),
-            SpaceBundle {
-                saved_objects: vec![
-                    json!({"type": "dashboard", "id": "dash-1"}),
-                    json!({"type": "dashboard", "id": "dash-2"}),
-                ],
-                workflows: vec![
-                    json!({"id": "workflow-1", "name": "Workflow One"}),
-                    json!({"id": "workflow-2", "name": "Workflow Two"}),
-                ],
-                agents: vec![
-                    json!({"id": "agent-1", "name": "Agent One"}),
-                    json!({"id": "agent-2", "name": "Agent Two"}),
-                ],
-                tools: vec![
-                    json!({"id": "tool-1", "name": "Tool One"}),
-                    json!({"id": "tool-2", "name": "Tool Two"}),
-                ],
-                skills: vec![
-                    json!({"id": "skill-1", "name": "Skill One", "content": "Body one\n"}),
-                    json!({"id": "skill-2", "name": "Skill Two", "content": "Body two\n"}),
-                ],
-            },
-        );
-        fs_bundle.write(&bundle).unwrap();
-
-        SavedObjectsManifest::with_objects(vec![SavedObject::new("dashboard", "dash-2")])
-            .write(bundle_path.join("default/manifest/saved_objects.json"))
-            .unwrap();
-        WorkflowsManifest::with_workflows(vec![WorkflowEntry::new("workflow-2", "Workflow Two")])
-            .write(bundle_path.join("default/manifest/workflows.yml"))
-            .unwrap();
-        AgentsManifest::with_agents(vec![AgentEntry::new("agent-2", "Agent Two")])
-            .write(bundle_path.join("default/manifest/agents.yml"))
-            .unwrap();
-        ToolsManifest::with_tools(vec!["tool-2".to_string()])
-            .write(bundle_path.join("default/manifest/tools.yml"))
-            .unwrap();
-        SkillsManifest::with_skills(vec![SkillEntry::new("skill-2", "Skill Two")])
-            .write(bundle_path.join("default/manifest/skills.yml"))
-            .unwrap();
-
-        write_json_file(
-            &bundle_path.join("default/tools/extra.json"),
-            &json!({"id": "extra-tool", "name": "Extra Tool"}),
-        )
-        .unwrap();
-
-        let read = KibanaFsBundle::open(&bundle_path)
-            .unwrap()
-            .read_all()
-            .unwrap();
-        let space = &read.by_space["default"];
-
-        assert_eq!(space.saved_objects.len(), 1);
-        assert_eq!(space.saved_objects[0]["id"], "dash-2");
-        assert_eq!(space.workflows.len(), 1);
-        assert_eq!(space.workflows[0]["id"], "workflow-2");
-        assert_eq!(space.agents.len(), 1);
-        assert_eq!(space.agents[0]["id"], "agent-2");
-        assert_eq!(space.tools.len(), 1);
-        assert_eq!(space.tools[0]["id"], "tool-2");
-        assert_eq!(space.skills.len(), 1);
-        assert_eq!(space.skills[0]["id"], "skill-2");
-    }
-
-    #[test]
-    fn manifest_listed_missing_resource_is_an_error() {
-        let temp = TempDir::new().unwrap();
-        let bundle_path = temp.path().join("bundle");
-        let fs_bundle = KibanaFsBundle::create(&bundle_path).unwrap();
-
-        let mut bundle = SyncBundle::default();
-        bundle.by_space.insert(
-            "default".to_string(),
-            SpaceBundle {
-                tools: vec![json!({"id": "tool-1", "name": "Tool One"})],
-                ..SpaceBundle::default()
-            },
-        );
-        fs_bundle.write(&bundle).unwrap();
-
-        ToolsManifest::with_tools(vec!["missing-tool".to_string()])
-            .write(bundle_path.join("default/manifest/tools.yml"))
-            .unwrap();
-
-        let err = KibanaFsBundle::open(&bundle_path)
-            .unwrap()
-            .read_all()
-            .unwrap_err();
-
-        assert!(err.to_string().contains("missing-tool"));
-        assert!(err.to_string().contains("listed in the manifest"));
-    }
-
-    #[test]
-    fn manifest_listed_missing_skill_is_an_error() {
-        let temp = TempDir::new().unwrap();
-        let bundle_path = temp.path().join("bundle");
-        let fs_bundle = KibanaFsBundle::create(&bundle_path).unwrap();
-
-        let mut bundle = SyncBundle::default();
-        bundle.by_space.insert(
-            "default".to_string(),
-            SpaceBundle {
-                skills: vec![json!({"id": "skill-1", "name": "Skill One", "content": "Body\n"})],
-                ..SpaceBundle::default()
-            },
-        );
-        fs_bundle.write(&bundle).unwrap();
-
-        SkillsManifest::with_skills(vec![SkillEntry::new("missing-skill", "Missing Skill")])
-            .write(bundle_path.join("default/manifest/skills.yml"))
-            .unwrap();
-
-        let err = KibanaFsBundle::open(&bundle_path)
-            .unwrap()
-            .read_all()
-            .unwrap_err();
-
-        assert!(err.to_string().contains("missing-skill"));
-        assert!(err.to_string().contains("listed in the manifest"));
-        assert!(err.to_string().contains("SKILL.md"));
-    }
-
-    #[test]
-    fn manifest_listed_skill_without_skills_directory_is_an_error() {
-        let temp = TempDir::new().unwrap();
-        let bundle_path = temp.path().join("bundle");
-        KibanaFsBundle::create(&bundle_path).unwrap();
-
-        SkillsManifest::with_skills(vec![SkillEntry::new("missing-skill", "Missing Skill")])
-            .write(bundle_path.join("default/manifest/skills.yml"))
-            .unwrap();
-
-        let err = KibanaFsBundle::open(&bundle_path)
-            .unwrap()
-            .read_all()
-            .unwrap_err();
-
-        assert!(err.to_string().contains("missing-skill"));
-        assert!(err.to_string().contains("listed in the manifest"));
-        assert!(err.to_string().contains("SKILL.md"));
-    }
-
-    #[test]
-    fn symlinked_skill_directory_is_an_error() {
-        let temp = TempDir::new().unwrap();
-        let bundle_path = temp.path().join("bundle");
-        let skills_path = bundle_path.join("default/skills");
-        let outside_path = temp.path().join("outside-skill");
-        std::fs::create_dir_all(&skills_path).unwrap();
-        std::fs::create_dir(&outside_path).unwrap();
-        std::fs::write(
-            outside_path.join("SKILL.md"),
-            "---\nid: outside-skill\n---\nBody\n",
-        )
-        .unwrap();
-        symlink_dir(&outside_path, &skills_path.join("linked")).unwrap();
-
-        let err = KibanaFsBundle::open(&bundle_path)
-            .unwrap()
-            .read_all()
-            .unwrap_err();
-
-        assert!(
-            err.to_string()
-                .contains("skill directory cannot be a symlink")
-        );
-    }
-
-    #[test]
-    fn missing_root_is_an_error_for_open() {
-        let temp = TempDir::new().unwrap();
-        let result = KibanaFsBundle::open(temp.path().join("missing"));
-
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn reads_json5_resources_from_directories() {
-        let temp = TempDir::new().unwrap();
-        let resources_dir = temp.path().join("resources");
-        std::fs::create_dir(&resources_dir).unwrap();
-        std::fs::write(
-            resources_dir.join("resource.json"),
-            r#"{
-                // Comments and trailing commas are valid.
-                id: "resource-1",
-                definition: """first line
-second line""",
-            }"#,
-        )
-        .unwrap();
-
-        let resources = read_json_dir(&resources_dir).unwrap();
-
-        assert_eq!(resources.len(), 1);
-        assert_eq!(resources[0]["id"], "resource-1");
-        assert_eq!(resources[0]["definition"], "first line\nsecond line");
-    }
-
-    #[cfg(unix)]
-    fn symlink_dir(source: &Path, link: &Path) -> std::io::Result<()> {
-        std::os::unix::fs::symlink(source, link)
-    }
-
-    #[cfg(windows)]
-    fn symlink_dir(source: &Path, link: &Path) -> std::io::Result<()> {
-        std::os::windows::fs::symlink_dir(source, link)
     }
 }

--- a/crates/kibana-sync/src/fs.rs
+++ b/crates/kibana-sync/src/fs.rs
@@ -82,6 +82,9 @@ impl FilesystemWriter {
     fn write_spaces(&self, spaces: &[Value]) -> Result<()> {
         let mut entries = Vec::with_capacity(spaces.len());
         for space in spaces {
+            if !space.is_object() {
+                return Err(Error::message("space must be a JSON object"));
+            }
             let id = required_str(space, "id", "space")?;
             let name = optional_str(space, "name").unwrap_or(id);
             entries.push(SpaceEntry::new(id.to_string(), name.to_string()));

--- a/crates/kibana-sync/src/fs.rs
+++ b/crates/kibana-sync/src/fs.rs
@@ -89,7 +89,15 @@ impl FilesystemWriter {
         SpacesManifest::with_spaces(entries).write(self.root.join("spaces.yml"))?;
         for space in spaces {
             let id = required_str(space, "id", "space")?;
-            write_json_file(&self.root.join(id).join("space.json"), space)?;
+            let mut definition = space.clone();
+            let object = definition
+                .as_object_mut()
+                .ok_or(Error::MissingResourceId { resource: "space" })?;
+            object.insert("id".to_string(), Value::String(id.to_string()));
+            if object.get("name").and_then(Value::as_str).is_none() {
+                object.insert("name".to_string(), Value::String(id.to_string()));
+            }
+            write_json_file(&self.root.join(id).join("space.json"), &definition)?;
         }
         Ok(())
     }

--- a/crates/kibana-sync/src/kibana/skills/mod.rs
+++ b/crates/kibana-sync/src/kibana/skills/mod.rs
@@ -10,6 +10,7 @@ mod storage;
 pub use extractor::{SkillsExtractor, parse_skills_response};
 pub use loader::SkillsLoader;
 pub use manifest::{SkillEntry, SkillsManifest};
+pub(crate) use storage::skill_files_to_value;
 pub use storage::{
     ReferencedContent, SkillFrontmatter, read_skill_directory, sanitize_path_component,
     skill_directory_name, skill_to_directory, skill_to_value,

--- a/crates/kibana-sync/src/kibana/skills/mod.rs
+++ b/crates/kibana-sync/src/kibana/skills/mod.rs
@@ -10,7 +10,7 @@ mod storage;
 pub use extractor::{SkillsExtractor, parse_skills_response};
 pub use loader::SkillsLoader;
 pub use manifest::{SkillEntry, SkillsManifest};
-pub(crate) use storage::skill_files_to_value;
+pub(crate) use storage::{REFERENCED_CONTENT_METADATA_FILE, SKILL_FILE, skill_files_to_value};
 pub use storage::{
     ReferencedContent, SkillFrontmatter, read_skill_directory, sanitize_path_component,
     skill_directory_name, skill_to_directory, skill_to_value,

--- a/crates/kibana-sync/src/kibana/skills/storage.rs
+++ b/crates/kibana-sync/src/kibana/skills/storage.rs
@@ -163,6 +163,14 @@ pub fn skill_to_directory(root: &Path, skill: &Value) -> Result<PathBuf> {
 }
 
 pub fn read_skill_directory(directory: &Path) -> Result<SkillDirectory> {
+    let directory_metadata = std::fs::symlink_metadata(directory)
+        .with_context(|| format!("Failed to inspect skill directory: {}", directory.display()))?;
+    if directory_metadata.file_type().is_symlink() {
+        return Err(Error::message(format!(
+            "skill directory cannot be a symlink: {}",
+            directory.display()
+        )));
+    }
     let canonical_directory = directory
         .canonicalize()
         .with_context(|| format!("Failed to resolve skill directory: {}", directory.display()))?;
@@ -913,6 +921,23 @@ mod tests {
         assert!(
             err.to_string()
                 .contains("skill file escapes skill directory")
+        );
+    }
+
+    #[test]
+    fn rejects_skill_directory_symlink() {
+        let temp = TempDir::new().unwrap();
+        let target = temp.path().join("target");
+        std::fs::create_dir(&target).unwrap();
+        std::fs::write(target.join(SKILL_FILE), "---\nid: skill\n---\nBody\n").unwrap();
+        let link = temp.path().join("link");
+        symlink_dir(&target, &link).unwrap();
+
+        let err = read_skill_directory(&link).unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("skill directory cannot be a symlink")
         );
     }
 

--- a/crates/kibana-sync/src/kibana/skills/storage.rs
+++ b/crates/kibana-sync/src/kibana/skills/storage.rs
@@ -202,6 +202,7 @@ pub fn read_skill_directory(directory: &Path) -> Result<SkillDirectory> {
         .collect::<Result<Vec<_>>>()?;
     let metadata_path = directory.join(REFERENCED_CONTENT_METADATA_FILE);
     let metadata = if metadata_path.exists() {
+        validate_file_within_directory(&canonical_directory, &metadata_path)?;
         Some(std::fs::read_to_string(&metadata_path).with_context(|| {
             format!(
                 "Failed to read referenced content metadata: {}",
@@ -213,6 +214,27 @@ pub fn read_skill_directory(directory: &Path) -> Result<SkillDirectory> {
     };
 
     skill_files_to_directory(&content, referenced_files, metadata.as_deref())
+}
+
+fn validate_file_within_directory(canonical_directory: &Path, path: &Path) -> Result<()> {
+    let metadata = std::fs::symlink_metadata(path)
+        .with_context(|| format!("Failed to inspect path: {}", path.display()))?;
+    if metadata.file_type().is_symlink() {
+        return Err(Error::message(format!(
+            "path uses symlink traversal inside skill directory: {}",
+            path.display()
+        )));
+    }
+    let canonical = path
+        .canonicalize()
+        .with_context(|| format!("Failed to resolve path: {}", path.display()))?;
+    if !canonical.starts_with(canonical_directory) {
+        return Err(Error::message(format!(
+            "path escapes skill directory: {}",
+            path.display()
+        )));
+    }
+    Ok(())
 }
 
 pub fn skill_to_value(directory: &Path, include_id: bool) -> Result<Value> {
@@ -892,6 +914,21 @@ mod tests {
             err.to_string()
                 .contains("skill file escapes skill directory")
         );
+    }
+
+    #[test]
+    fn rejects_referenced_content_metadata_symlink_escape() {
+        let temp = TempDir::new().unwrap();
+        let skill_dir = temp.path().join("skill");
+        std::fs::create_dir(&skill_dir).unwrap();
+        std::fs::write(skill_dir.join(SKILL_FILE), "---\nid: skill\n---\nBody\n").unwrap();
+        let outside = temp.path().join("metadata.yml");
+        std::fs::write(&outside, "entries: []\n").unwrap();
+        symlink_file(&outside, &skill_dir.join(REFERENCED_CONTENT_METADATA_FILE)).unwrap();
+
+        let err = read_skill_directory(&skill_dir).unwrap_err();
+
+        assert!(err.to_string().contains("symlink traversal"));
     }
 
     #[test]

--- a/crates/kibana-sync/src/kibana/skills/storage.rs
+++ b/crates/kibana-sync/src/kibana/skills/storage.rs
@@ -8,8 +8,8 @@ use std::{
     path::{Component, Path, PathBuf},
 };
 
-const SKILL_FILE: &str = "SKILL.md";
-const REFERENCED_CONTENT_METADATA_FILE: &str = ".referenced_content.yml";
+pub(crate) const SKILL_FILE: &str = "SKILL.md";
+pub(crate) const REFERENCED_CONTENT_METADATA_FILE: &str = ".referenced_content.yml";
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct SkillFrontmatter {
@@ -219,16 +219,25 @@ pub fn read_skill_directory(directory: &Path) -> Result<SkillDirectory> {
         })
         .collect::<Result<Vec<_>>>()?;
     let metadata_path = directory.join(REFERENCED_CONTENT_METADATA_FILE);
-    let metadata = if metadata_path.exists() {
-        validate_file_within_directory(&canonical_directory, &metadata_path)?;
-        Some(std::fs::read_to_string(&metadata_path).with_context(|| {
-            format!(
-                "Failed to read referenced content metadata: {}",
-                metadata_path.display()
-            )
-        })?)
-    } else {
-        None
+    let metadata = match std::fs::symlink_metadata(&metadata_path) {
+        Ok(_) => {
+            validate_file_within_directory(&canonical_directory, &metadata_path)?;
+            Some(std::fs::read_to_string(&metadata_path).with_context(|| {
+                format!(
+                    "Failed to read referenced content metadata: {}",
+                    metadata_path.display()
+                )
+            })?)
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+        Err(error) => {
+            return Err(error).with_context(|| {
+                format!(
+                    "Failed to inspect referenced content metadata: {}",
+                    metadata_path.display()
+                )
+            });
+        }
     };
 
     skill_files_to_directory(&content, referenced_files, metadata.as_deref())
@@ -957,8 +966,7 @@ mod tests {
         let skill_dir = temp.path().join("skill");
         std::fs::create_dir(&skill_dir).unwrap();
         std::fs::write(skill_dir.join(SKILL_FILE), "---\nid: skill\n---\nBody\n").unwrap();
-        let outside = temp.path().join("metadata.yml");
-        std::fs::write(&outside, "entries: []\n").unwrap();
+        let outside = temp.path().join("missing-metadata.yml");
         symlink_file(&outside, &skill_dir.join(REFERENCED_CONTENT_METADATA_FILE)).unwrap();
 
         let err = read_skill_directory(&skill_dir).unwrap_err();

--- a/crates/kibana-sync/src/kibana/skills/storage.rs
+++ b/crates/kibana-sync/src/kibana/skills/storage.rs
@@ -175,6 +175,16 @@ pub fn read_skill_directory(directory: &Path) -> Result<SkillDirectory> {
         .canonicalize()
         .with_context(|| format!("Failed to resolve skill directory: {}", directory.display()))?;
     let skill_file = directory.join(SKILL_FILE);
+    if std::fs::symlink_metadata(&skill_file)
+        .with_context(|| format!("Failed to inspect skill file: {}", skill_file.display()))?
+        .file_type()
+        .is_symlink()
+    {
+        return Err(Error::message(format!(
+            "skill file cannot be a symlink: {}",
+            skill_file.display()
+        )));
+    }
     let canonical_skill_file = skill_file
         .canonicalize()
         .with_context(|| format!("Failed to resolve skill file: {}", skill_file.display()))?;
@@ -920,7 +930,7 @@ mod tests {
 
         assert!(
             err.to_string()
-                .contains("skill file escapes skill directory")
+                .contains("skill file cannot be a symlink")
         );
     }
 

--- a/crates/kibana-sync/src/kibana/skills/storage.rs
+++ b/crates/kibana-sync/src/kibana/skills/storage.rs
@@ -179,18 +179,105 @@ pub fn read_skill_directory(directory: &Path) -> Result<SkillDirectory> {
 
     let content = std::fs::read_to_string(&skill_file)
         .with_context(|| format!("Failed to read skill file: {}", skill_file.display()))?;
-    let (frontmatter, body) = parse_skill_markdown(&content)?;
-    let referenced_content = read_referenced_content(directory)?;
+    let mut files = Vec::new();
+    collect_markdown_files(&canonical_directory, directory, &mut files)?;
+    files.sort();
+    let referenced_files = files
+        .into_iter()
+        .map(|path| {
+            let relative = path
+                .strip_prefix(directory)
+                .map_err(|_| {
+                    Error::message(format!(
+                        "referenced content escaped skill directory: {}",
+                        path.display()
+                    ))
+                })?
+                .to_path_buf();
+            let content = std::fs::read_to_string(&path).with_context(|| {
+                format!("Failed to read referenced content: {}", path.display())
+            })?;
+            Ok((relative, content))
+        })
+        .collect::<Result<Vec<_>>>()?;
+    let metadata_path = directory.join(REFERENCED_CONTENT_METADATA_FILE);
+    let metadata = if metadata_path.exists() {
+        Some(std::fs::read_to_string(&metadata_path).with_context(|| {
+            format!(
+                "Failed to read referenced content metadata: {}",
+                metadata_path.display()
+            )
+        })?)
+    } else {
+        None
+    };
+
+    skill_files_to_directory(&content, referenced_files, metadata.as_deref())
+}
+
+pub fn skill_to_value(directory: &Path, include_id: bool) -> Result<Value> {
+    Ok(read_skill_directory(directory)?.to_value(include_id))
+}
+
+pub(crate) fn skill_files_to_value(
+    skill_markdown: &str,
+    referenced_files: impl IntoIterator<Item = (PathBuf, String)>,
+    metadata_yaml: Option<&str>,
+    include_id: bool,
+) -> Result<Value> {
+    Ok(
+        skill_files_to_directory(skill_markdown, referenced_files, metadata_yaml)?
+            .to_value(include_id),
+    )
+}
+
+fn skill_files_to_directory(
+    skill_markdown: &str,
+    referenced_files: impl IntoIterator<Item = (PathBuf, String)>,
+    metadata_yaml: Option<&str>,
+) -> Result<SkillDirectory> {
+    let (frontmatter, body) = parse_skill_markdown(skill_markdown)?;
+    let metadata = metadata_yaml
+        .map(|content| {
+            yaml_serde::from_str(content).context("Failed to parse referenced content metadata")
+        })
+        .transpose()?
+        .unwrap_or_default();
+    let mut referenced_content = referenced_files
+        .into_iter()
+        .map(|(relative, content)| {
+            let parent = relative.parent().unwrap_or_else(|| Path::new(""));
+            let metadata_entry = metadata_entry_for(&metadata, &relative)?;
+            let relative_path = metadata_entry
+                .map(|entry| entry.relative_path.clone())
+                .unwrap_or_else(|| path_to_api_relative_path(parent));
+            let name = if let Some(entry) = metadata_entry {
+                entry.name.clone()
+            } else {
+                relative
+                    .file_stem()
+                    .and_then(|stem| stem.to_str())
+                    .ok_or_else(|| Error::message("referenced content filename is not UTF-8"))?
+                    .to_string()
+            };
+            Ok(ReferencedContent {
+                name,
+                relative_path,
+                content,
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+    referenced_content.sort_by(|left, right| {
+        left.relative_path
+            .cmp(&right.relative_path)
+            .then_with(|| left.name.cmp(&right.name))
+    });
 
     Ok(SkillDirectory {
         frontmatter,
         content: body.to_string(),
         referenced_content,
     })
-}
-
-pub fn skill_to_value(directory: &Path, include_id: bool) -> Result<Value> {
-    Ok(read_skill_directory(directory)?.to_value(include_id))
 }
 
 pub fn sanitize_path_component(value: &str) -> String {
@@ -350,71 +437,6 @@ fn write_referenced_content(root: &Path, entries: &[ReferencedContent]) -> Resul
 
     write_referenced_content_metadata(root, &metadata)?;
     Ok(())
-}
-
-fn read_referenced_content(root: &Path) -> Result<Vec<ReferencedContent>> {
-    let canonical_root = root
-        .canonicalize()
-        .with_context(|| format!("Failed to resolve skill directory: {}", root.display()))?;
-    let mut files = Vec::new();
-    collect_markdown_files(&canonical_root, root, &mut files)?;
-    files.sort();
-    let metadata = read_referenced_content_metadata(root)?;
-
-    let mut entries = files
-        .into_iter()
-        .map(|path| {
-            let relative = path.strip_prefix(root).map_err(|_| {
-                Error::message(format!(
-                    "referenced content escaped skill directory: {}",
-                    path.display()
-                ))
-            })?;
-            let parent = relative.parent().unwrap_or_else(|| Path::new(""));
-            let metadata_entry = metadata_entry_for(&metadata, relative)?;
-            let relative_path = metadata_entry
-                .map(|entry| entry.relative_path.clone())
-                .unwrap_or_else(|| path_to_api_relative_path(parent));
-            let name = if let Some(entry) = metadata_entry {
-                entry.name.clone()
-            } else {
-                path.file_stem()
-                    .and_then(|stem| stem.to_str())
-                    .ok_or_else(|| Error::message("referenced content filename is not UTF-8"))?
-                    .to_string()
-            };
-            let content = std::fs::read_to_string(&path).with_context(|| {
-                format!("Failed to read referenced content: {}", path.display())
-            })?;
-            Ok(ReferencedContent {
-                name,
-                relative_path,
-                content,
-            })
-        })
-        .collect::<Result<Vec<_>>>()?;
-    entries.sort_by(|left, right| {
-        left.relative_path
-            .cmp(&right.relative_path)
-            .then_with(|| left.name.cmp(&right.name))
-    });
-
-    Ok(entries)
-}
-
-fn read_referenced_content_metadata(root: &Path) -> Result<ReferencedContentMetadata> {
-    let path = root.join(REFERENCED_CONTENT_METADATA_FILE);
-    if !path.exists() {
-        return Ok(ReferencedContentMetadata::default());
-    }
-
-    let content = std::fs::read_to_string(&path).with_context(|| {
-        format!(
-            "Failed to read referenced content metadata: {}",
-            path.display()
-        )
-    })?;
-    yaml_serde::from_str(&content).context("Failed to parse referenced content metadata")
 }
 
 fn write_referenced_content_metadata(

--- a/crates/kibana-sync/src/lib.rs
+++ b/crates/kibana-sync/src/lib.rs
@@ -2,14 +2,15 @@
 //!
 //! This crate owns Kibana HTTP client configuration, authentication, version
 //! and capability checks, space-aware request routing, endpoint modules,
-//! dependency discovery, storage-neutral sync helpers, and explicit filesystem
-//! bundle helpers. It does not discover `kibob` project roots or initialize
+//! dependency discovery, storage-neutral sync helpers, and generic filesystem
+//! or entry-backed bundle helpers. It does not discover `kibob` project roots or initialize
 //! logging/tracing subscribers.
 
+pub mod bundle;
 pub mod client;
 pub mod error;
 pub mod etl;
-pub mod fs;
+mod fs;
 pub mod json5;
 pub mod kibana;
 pub mod sync;
@@ -17,10 +18,10 @@ pub mod sync;
 #[cfg(test)]
 pub(crate) mod test_support;
 
+pub use bundle::{BundleSource, Entries, Filesystem, KibanaBundle};
 pub use client::{
     ApiCapability, Auth, KibanaClient, KibanaClientBuilder, KibanaVersion, KibanaVersionInfo,
     SpaceRegistry, parse_kibana_version,
 };
 pub use error::{Error, Result, ResultContext};
 pub use etl::{Extractor, IdentityTransformer, Loader, Pipeline, Transformer};
-pub use fs::KibanaFsBundle;

--- a/crates/kibana-sync/src/lib.rs
+++ b/crates/kibana-sync/src/lib.rs
@@ -18,7 +18,7 @@ pub mod sync;
 #[cfg(test)]
 pub(crate) mod test_support;
 
-pub use bundle::{BundleSource, Entries, Filesystem, KibanaBundle};
+pub use bundle::{Entries, Filesystem, KibanaBundle};
 pub use client::{
     ApiCapability, Auth, KibanaClient, KibanaClientBuilder, KibanaVersion, KibanaVersionInfo,
     SpaceRegistry, parse_kibana_version,

--- a/crates/kibana-sync/src/sync.rs
+++ b/crates/kibana-sync/src/sync.rs
@@ -68,7 +68,7 @@ impl Default for SyncOptions {
     }
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct SpaceBundle {
     pub saved_objects: Vec<Value>,
     pub workflows: Vec<Value>,
@@ -77,7 +77,7 @@ pub struct SpaceBundle {
     pub skills: Vec<Value>,
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct SyncBundle {
     pub spaces: Vec<Value>,
     pub by_space: HashMap<String, SpaceBundle>,

--- a/openspec/changes/embedded-assets/.openspec.yaml
+++ b/openspec/changes/embedded-assets/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-10

--- a/openspec/changes/embedded-assets/design.md
+++ b/openspec/changes/embedded-assets/design.md
@@ -1,0 +1,133 @@
+## Context
+
+`KibanaFsBundle` currently combines two responsibilities: access to an operating-system directory tree and interpretation of the Kibana bundle layout. Its read path calls `Path::exists`, `std::fs::read_dir`, and `std::fs::read_to_string` directly, while skill projection expects a real skill directory so it can discover `SKILL.md` and referenced Markdown files. This prevents ESDiag and similar consumers from loading assets exposed as relative paths and bytes without first creating a temporary directory or duplicating the layout parser.
+
+The established behavior is broader than parsing JSON files. The reader discovers spaces from `spaces.yml` and space directories, honors per-space manifests as ordering and selection authorities, recursively parses JSON5 resources, validates manifest references, and converts complete skill directory trees into Kibana values. The stable layout and parsing behavior must remain intact, but `KibanaFsBundle` source compatibility is unnecessary because the only two consumers are this workspace and ESDiag, both of which can migrate before the first public release.
+
+Data flow after this change is:
+
+```text
+KibanaBundle<Filesystem> --+
+                           +-> BundleSource -> manifests / JSON5 / skill projection
+KibanaBundle<Entries<B>> --+                    -> SyncBundle
+                                                -> push_sync ETL loaders
+                                                -> Kibana APIs
+```
+
+The change affects only the extraction side of the sync ETL pipeline. `SyncBundle`, dependency expansion, transforms, and Kibana loaders remain storage-neutral and unchanged.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Load a complete Kibana asset bundle from relative-path and byte-content entries without filesystem materialization.
+- Produce the same `SyncBundle` content, ordering, selection behavior, and validation outcomes as filesystem reads.
+- Preserve JSON5 support and complete skill projection, including nested referenced content and its metadata.
+- Provide one generic `KibanaBundle<S>` API with compile-time backend capabilities.
+- Keep filesystem bundle layout and read/write behavior while allowing both consumers to migrate to the generic API.
+- Reject paths that could escape the entry root or make lookup ambiguous.
+- Keep the reader synchronous and free of new runtime dependencies.
+
+**Non-Goals:**
+- Add write support for entry-backed sources.
+- Model operating-system metadata, permissions, symlinks, or modification times in entry-backed sources.
+- Change the stable on-disk bundle layout, manifest schemas, `SyncBundle`, or Kibana API behavior.
+- Add archive-format readers, asset compression, proc macros, or build scripts.
+- Expose a fully general virtual filesystem abstraction in the first version.
+
+## Decisions
+
+### 1) Make the bundle generic over a source backend
+
+Replace `KibanaFsBundle` with these public types:
+
+```rust
+pub struct KibanaBundle<S> {
+    source: S,
+}
+
+pub struct Filesystem {
+    root: PathBuf,
+}
+
+pub struct Entries<B> {
+    files: BTreeMap<String, B>,
+}
+```
+
+`KibanaBundle<Filesystem>` provides `open`, `create`, `root`, and `write`. `KibanaBundle<Entries<B>>` provides `from_entries` when `B: AsRef<[u8]>`. Both provide `read_all` and `read` through their `BundleSource` implementation. The source trait is sealed initially so the crate can refine its minimal traversal contract without committing to a general virtual filesystem API.
+
+The byte storage type belongs to the caller. Static embedded assets use `&'static [u8]`, dynamically collected assets use `Vec<u8>`, and consumers needing shared ownership can use `Arc<[u8]>`. A single entry collection uses one byte storage type; callers that need mixed ownership can choose their own uniform enum or shared representation.
+
+Rationale: backend generics make filesystem-only operations unavailable on entry-backed bundles at compile time, avoid lifetime-heavy `Cow` APIs, and let Rust infer content ownership from the supplied collection. Entry pairs match ESDiag's in-memory directory model and can represent every stable bundle asset.
+
+Alternative considered: use a single bundle containing a filesystem-or-entries enum. Rejected because `root` and `write` would then require runtime errors or optional results for entry-backed bundles. Separate `KibanaFsBundle` and `KibanaVirtualBundle` types were also rejected because they duplicate the common API and obscure that both are the same parser over different sources.
+
+### 2) Separate source access from bundle interpretation
+
+Define a sealed `BundleSource` interface with the minimal operations needed by bundle parsing: test for a file or directory prefix, enumerate immediate or recursive entries, and read file bytes. Implement it for `Filesystem` and `Entries<B>`. Move space discovery, manifest loading, JSON resource loading, manifest filtering, and skill tree projection into generic `KibanaBundle<S>` reader methods.
+
+Filesystem-only safety checks such as rejecting symlinked skill directories remain in `Filesystem`. Filesystem construction and writing are specialized inherent implementations on `KibanaBundle<Filesystem>` rather than part of `BundleSource`.
+
+Rationale: a single interpretation path prevents the entry-backed reader from drifting from filesystem behavior. Source backends own access-specific concerns; parsing owns bundle semantics.
+
+Alternative considered: implement a second parser over a `BTreeMap<PathBuf, bytes>`. Rejected because manifest, discovery, JSON5, and skill behavior would immediately be duplicated.
+
+### 3) Treat paths as normalized, root-relative logical bundle paths
+
+`Entries<B>` construction accepts only non-empty relative paths. It normalizes platform separators to the bundle's logical separator and rejects absolute paths, parent traversal, root/prefix components, empty terminal names, and duplicate normalized paths. Directory entries are implicit from file path prefixes; callers provide files only. Paths are compared and sorted using their normalized logical form.
+
+Case remains significant, matching the stable bundle names and avoiding silent aliasing on case-sensitive consumers. Exact duplicate normalized paths are errors rather than last-write-wins.
+
+Rationale: embedded bundles have no operating-system root to contain traversal. Validating at construction establishes a safe and deterministic namespace before any parsing occurs.
+
+Alternative considered: silently clean `.` and `..` components. Rejected because accepting traversal-shaped input can hide producer mistakes and create ambiguous duplicate paths.
+
+### 4) Parse text from bytes at the source-neutral boundary
+
+Manifest, JSON5, `SKILL.md`, referenced-content Markdown, and skill metadata readers decode required text files as UTF-8 and attach the normalized logical path to parse and decoding errors. JSON resources retain the current recursive `.json` discovery, lexicographic ordering, and `json5::from_json5_str` behavior. YAML and JSON manifests continue using their existing schemas and source-of-truth semantics.
+
+Rationale: byte entries support normal embedding APIs while explicit UTF-8 validation preserves the text formats' current expectations and provides useful diagnostics.
+
+Alternative considered: require entry content as `str`. Rejected because common embedding and in-memory directory APIs expose bytes, and rejecting non-UTF-8 should happen only when a selected textual resource is read.
+
+### 5) Project skills directly from their logical directory tree
+
+Extract the format-level portions of `skill_to_value` so they can consume a logical skill directory and its text entries rather than requiring `Path::canonicalize` and `std::fs` traversal. A skill is discoverable only when an immediate child of `<space>/skills/` contains `SKILL.md`. Nested Markdown referenced content and the existing reference metadata file are read using normalized relative paths, with the same ordering, names, relative paths, and validation as filesystem projection.
+
+Filesystem projection continues to enforce canonical-root containment and reject symlinked skill directories or referenced content. Entry-backed sources cannot contain symlinks, so their equivalent safety guarantee comes from constructor path validation.
+
+Rationale: materializing only skill directories would retain the original problem and introduce a hidden temporary-filesystem dependency.
+
+Alternative considered: represent each skill as a prebuilt Kibana JSON value in the entry API. Rejected because it bypasses the documented bundle layout and would force embedded consumers to duplicate skill parsing.
+
+### 6) Verify parity with source conformance fixtures
+
+Build one representative bundle fixture containing spaces, manifests, nested saved objects, workflows, agents, tools, JSON5 syntax, skills, reference metadata, and nested referenced content. Load it through `KibanaBundle<Filesystem>` and `KibanaBundle<Entries<&[u8]>>`, then assert equal `SyncBundle` results for `read_all` and representative selections. Add entry-only tests for invalid paths, duplicates, invalid UTF-8 in selected text assets, missing manifest resources, deterministic ordering, and empty bundles.
+
+Rationale: parity is the primary compatibility promise and is stronger when exercised against identical logical content.
+
+Alternative considered: maintain separate filesystem and entry-backed test fixtures. Rejected because differences between fixtures can conceal behavioral drift.
+
+## Risks / Trade-offs
+
+- [Risk] Refactoring mature filesystem parsing may regress current reads. -> Mitigation: route both sources through shared functions and retain existing filesystem tests alongside parity fixtures.
+- [Risk] A uniform `B` prevents mixing borrowed slices and owned vectors in one entry collection. -> Mitigation: typical producers already expose a uniform content type; callers with mixed ownership can normalize to `Vec<u8>`, `Arc<[u8]>`, or their own enum implementing `AsRef<[u8]>`.
+- [Risk] Generic compiler errors could expose internal source bounds. -> Mitigation: keep constructors specialized, document common inferred forms, and seal the source trait.
+- [Risk] Filesystem case and symlink behavior cannot be identical across platforms and entry-backed sources. -> Mitigation: define parity at the logical bundle-content level while keeping source-specific safety checks explicit.
+- [Risk] Eager indexing adds path metadata overhead for large bundles. -> Mitigation: borrow content where possible, store entries in sorted maps, and avoid copying file bytes during parsing unless required by a parser.
+- [Risk] Extracting skill projection could accidentally change API field construction. -> Mitigation: keep one projection implementation and test complete value equality, including referenced content.
+
+## Migration Plan
+
+1. Add the generic `KibanaBundle<S>`, sealed `BundleSource`, `Filesystem`, and `Entries<B>` types.
+2. Add normalized entry indexing and path validation, then move bundle discovery plus manifest/resource parsing into the generic reader.
+3. Refactor skill projection into source-neutral format parsing with filesystem-specific containment checks at the adapter boundary.
+4. Replace workspace `KibanaFsBundle` call sites with `KibanaBundle<Filesystem>` and export the generic API for ESDiag.
+5. Add shared parity fixtures and negative entry-source tests.
+6. Run formatting, clippy, the full workspace test suite, and crate documentation tests.
+
+Migrate the workspace and ESDiag together before publishing the next crate version. Rollback consists of reverting the generic API and reader refactor; no persistent data or bundle format changes are involved.
+
+## Open Questions
+
+None currently.

--- a/openspec/changes/embedded-assets/proposal.md
+++ b/openspec/changes/embedded-assets/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+Embedded consumers such as ESDiag cannot use `KibanaFsBundle` without first materializing bundled assets to a temporary directory because the reader is coupled to `std::fs`. A storage-neutral reader is needed so those consumers can reuse `kibana-sync` as the single parser and loader while preserving the established bundle layout and behavior.
+
+## What Changes
+
+- **BREAKING** Replace `KibanaFsBundle` with a generic `KibanaBundle<S>` whose backend determines its available operations.
+- Add a `Filesystem` backend for path-backed bundle reads and writes and an `Entries<B>` backend for embedded `(relative path, bytes)` assets where `B: AsRef<[u8]>`.
+- Share bundle discovery, manifest parsing, resource selection, JSON5 parsing, ordering, and validation across both generic backends.
+- Preserve complete skill-directory loading, including `SKILL.md`, referenced-content subdirectories, and reference metadata, without requiring real directories.
+- Reject unsafe, invalid, or ambiguous entry paths with actionable library errors.
+- Document the generic API, migrate both consumers, and test behavioral parity between filesystem-backed and entry-backed reads.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `kibana-sync`: Replace the filesystem-specific bundle type with a generic bundle abstraction supporting filesystem and entry-backed sources with equivalent read semantics.
+
+## Impact
+
+- Affected code: `crates/kibana-sync/src/fs.rs`, skill storage projection helpers, public exports, crate documentation, and bundle reader tests.
+- Public API: replaces `KibanaFsBundle` with `KibanaBundle<Filesystem>` and adds `KibanaBundle<Entries<B>>`; no compatibility alias is required before the first public release.
+- Consumers: embedded applications can load compile-time or in-memory assets directly and pass the resulting `SyncBundle` to existing push sync APIs.
+- Dependencies: no new runtime dependency is expected.

--- a/openspec/changes/embedded-assets/specs/kibana-sync/spec.md
+++ b/openspec/changes/embedded-assets/specs/kibana-sync/spec.md
@@ -1,0 +1,69 @@
+## ADDED Requirements
+
+### Requirement: Generic Bundle Source Reading
+The `kibana-sync` crate SHALL expose `KibanaBundle<S>` with a `Filesystem` source for path-backed reads and writes and an `Entries<B>` source for validated, root-relative file entries where `B: AsRef<[u8]>`. Both source types SHALL produce the same storage-neutral resource content, deterministic ordering, selection behavior, manifest validation, JSON5 parsing, and skill projection for equivalent logical bundles.
+
+#### Scenario: Restrict operations by source type
+- **GIVEN** a `KibanaBundle<Filesystem>`
+- **WHEN** a consumer uses the bundle API
+- **THEN** filesystem construction, root access, reads, and writes are available
+- **AND** a `KibanaBundle<Entries<B>>` exposes entry construction and reads without filesystem-only operations
+
+#### Scenario: Read all embedded bundle resources
+- **GIVEN** a `KibanaBundle<Entries<B>>` containing `spaces.yml` and per-space manifests plus saved objects, workflows, agents, tools, and skills
+- **WHEN** a consumer reads all resources from the entry-backed bundle
+- **THEN** the library returns a `SyncBundle` containing the discovered spaces and every supported resource family
+- **AND** no temporary files or directories are created
+
+#### Scenario: Read selected embedded bundle resources
+- **GIVEN** an entry-backed bundle containing multiple spaces and resource families
+- **WHEN** a consumer reads it with a `SyncSelection`
+- **THEN** the library loads only the selected spaces and resource families
+- **AND** applies the same selection semantics as a filesystem-backed `KibanaBundle`
+
+#### Scenario: Preserve manifest authority and resource ordering
+- **GIVEN** an entry-backed bundle whose per-space manifest lists a subset of available resource files in a defined order
+- **WHEN** the bundle is read
+- **THEN** the returned collection contains only matching manifest-listed resources in manifest order
+- **AND** a manifest-listed resource with no matching asset produces an error that identifies the resource and logical bundle path
+
+#### Scenario: Parse JSON5 resource entries
+- **GIVEN** a selected entry-backed `.json` resource containing supported JSON5 comments, trailing commas, unquoted keys, or multiline strings
+- **WHEN** the bundle is read
+- **THEN** the library parses it with the same JSON5 behavior as a filesystem bundle resource
+- **AND** any decode or parse error identifies the resource's logical relative path
+
+#### Scenario: Load a complete virtual skill directory
+- **GIVEN** an entry-backed skill directory containing `SKILL.md`, nested referenced Markdown content, and reference metadata
+- **WHEN** the bundle is read with skills enabled
+- **THEN** the library projects the skill and its referenced content into the same Kibana value produced from the equivalent filesystem directory
+- **AND** preserves referenced-content names, relative paths, content, and deterministic ordering
+
+#### Scenario: Discover spaces from virtual layout
+- **GIVEN** an entry-backed bundle with space entries in `spaces.yml` and a space directory containing supported resources but absent from that manifest
+- **WHEN** all resources are read
+- **THEN** the library discovers both space identifiers using the same rules as a filesystem-backed bundle
+
+#### Scenario: Reject unsafe entry paths
+- **GIVEN** an entry whose path is absolute, traverses a parent, has an invalid root component, or normalizes to an empty path
+- **WHEN** `KibanaBundle<Entries<B>>` is constructed
+- **THEN** construction fails before any resource is parsed
+- **AND** the error identifies the invalid entry path
+
+#### Scenario: Reject duplicate entry paths
+- **GIVEN** two entries that normalize to the same logical relative path
+- **WHEN** `KibanaBundle<Entries<B>>` is constructed
+- **THEN** construction fails with an error identifying the duplicate path
+- **AND** neither entry silently replaces the other
+
+#### Scenario: Accept caller-selected byte storage
+- **GIVEN** entry collections backed uniformly by borrowed byte slices, owned byte vectors, or shared byte buffers implementing `AsRef<[u8]>`
+- **WHEN** a consumer constructs `KibanaBundle<Entries<B>>`
+- **THEN** the bundle reads each representation through the same generic source API
+- **AND** does not require a library-specific borrowed-or-owned content wrapper
+
+#### Scenario: Preserve logical filesystem behavior
+- **GIVEN** equivalent logical assets in `KibanaBundle<Filesystem>` and `KibanaBundle<Entries<B>>`
+- **WHEN** both bundles are read
+- **THEN** they return equivalent `SyncBundle` values
+- **AND** the stable filesystem layout and write behavior remain unchanged

--- a/openspec/changes/embedded-assets/tasks.md
+++ b/openspec/changes/embedded-assets/tasks.md
@@ -1,0 +1,42 @@
+## 1. Generic Source Model
+
+- [ ] 1.1 Add `KibanaBundle<S>` with a sealed `BundleSource` contract for existence checks, traversal, and byte reads.
+- [ ] 1.2 Add `Filesystem` and generic `Entries<B: AsRef<[u8]>>` source types.
+- [ ] 1.3 Add root-relative logical path normalization and a deterministic entry index with implicit directories.
+- [ ] 1.4 Reject absolute paths, parent traversal, invalid root components, empty paths, and duplicate normalized entries with path-specific library errors.
+- [ ] 1.5 Add unit tests for source operations, path normalization, implicit directories, deterministic listing, invalid paths, and duplicate detection.
+
+## 2. Generic Bundle Reader
+
+- [ ] 2.1 Refactor space discovery, manifest loading, recursive JSON resource loading, JSON5 parsing, selection, and manifest filtering into `KibanaBundle<S: BundleSource>`.
+- [ ] 2.2 Implement `read_all` and `read` once for all readable bundle sources.
+- [ ] 2.3 Implement `open`, `create`, `root`, and `write` only for `KibanaBundle<Filesystem>` while preserving the stable layout and filesystem safety checks.
+- [ ] 2.4 Implement `from_entries` only for `KibanaBundle<Entries<B>>` without filesystem access or temporary materialization.
+- [ ] 2.5 Add tests covering generic reads, manifest ordering, missing-resource errors, explicit selections, and source-specific method behavior.
+
+## 3. Public API and Consumer Migration
+
+- [ ] 3.1 Export `KibanaBundle`, `Filesystem`, and `Entries<B>` from `kibana-sync` and remove the `KibanaFsBundle` public type.
+- [ ] 3.2 Migrate all `kibana-object-manager` filesystem bundle call sites to `KibanaBundle<Filesystem>`.
+- [ ] 3.3 Verify ESDiag can construct `KibanaBundle<Entries<B>>` directly from its in-memory directory entry type.
+- [ ] 3.4 Add tests for borrowed slices, owned vectors, shared buffers, empty entry bundles, automatic space discovery, selected resources, invalid UTF-8, and path-specific parse errors.
+
+## 4. Source-Neutral Skill Projection
+
+- [ ] 4.1 Separate skill frontmatter, body, referenced-content, and reference-metadata parsing from operating-system directory traversal.
+- [ ] 4.2 Adapt filesystem skill projection to the shared format parser while retaining canonical-root containment and symlink rejection.
+- [ ] 4.3 Implement entry-backed skill discovery from immediate skill directories containing `SKILL.md`, including nested referenced Markdown files and reference metadata.
+- [ ] 4.4 Add tests for skill manifest filtering, missing `SKILL.md`, nested referenced content, metadata path restoration, deterministic ordering, and filesystem/entry value equality.
+
+## 5. Parity and Documentation
+
+- [ ] 5.1 Create a shared representative bundle fixture covering spaces, every supported resource family, manifests, nested objects, JSON5, skills, and referenced content.
+- [ ] 5.2 Add conformance tests asserting `KibanaBundle<Filesystem>` and `KibanaBundle<Entries<&[u8]>>` `read_all` results are equal for the shared fixture.
+- [ ] 5.3 Add conformance tests asserting filesystem and entry-backed selected reads and validation failures are behaviorally equivalent.
+- [ ] 5.4 Document generic filesystem, `include_bytes!`, and dynamically collected in-memory usage in crate docs or the `kibana-sync` README.
+
+## 6. Verification
+
+- [ ] 6.1 Run `cargo fmt --all` and verify formatting.
+- [ ] 6.2 Run `cargo clippy --workspace --all-targets -- -D warnings` and resolve warnings.
+- [ ] 6.3 Run `cargo test --workspace` and confirm all unit, integration, conformance, and documentation tests pass.

--- a/openspec/changes/embedded-assets/tasks.md
+++ b/openspec/changes/embedded-assets/tasks.md
@@ -1,42 +1,42 @@
 ## 1. Generic Source Model
 
-- [ ] 1.1 Add `KibanaBundle<S>` with a sealed `BundleSource` contract for existence checks, traversal, and byte reads.
-- [ ] 1.2 Add `Filesystem` and generic `Entries<B: AsRef<[u8]>>` source types.
-- [ ] 1.3 Add root-relative logical path normalization and a deterministic entry index with implicit directories.
-- [ ] 1.4 Reject absolute paths, parent traversal, invalid root components, empty paths, and duplicate normalized entries with path-specific library errors.
-- [ ] 1.5 Add unit tests for source operations, path normalization, implicit directories, deterministic listing, invalid paths, and duplicate detection.
+- [x] 1.1 Add `KibanaBundle<S>` with a sealed `BundleSource` contract for existence checks, traversal, and byte reads.
+- [x] 1.2 Add `Filesystem` and generic `Entries<B: AsRef<[u8]>>` source types.
+- [x] 1.3 Add root-relative logical path normalization and a deterministic entry index with implicit directories.
+- [x] 1.4 Reject absolute paths, parent traversal, invalid root components, empty paths, and duplicate normalized entries with path-specific library errors.
+- [x] 1.5 Add unit tests for source operations, path normalization, implicit directories, deterministic listing, invalid paths, and duplicate detection.
 
 ## 2. Generic Bundle Reader
 
-- [ ] 2.1 Refactor space discovery, manifest loading, recursive JSON resource loading, JSON5 parsing, selection, and manifest filtering into `KibanaBundle<S: BundleSource>`.
-- [ ] 2.2 Implement `read_all` and `read` once for all readable bundle sources.
-- [ ] 2.3 Implement `open`, `create`, `root`, and `write` only for `KibanaBundle<Filesystem>` while preserving the stable layout and filesystem safety checks.
-- [ ] 2.4 Implement `from_entries` only for `KibanaBundle<Entries<B>>` without filesystem access or temporary materialization.
-- [ ] 2.5 Add tests covering generic reads, manifest ordering, missing-resource errors, explicit selections, and source-specific method behavior.
+- [x] 2.1 Refactor space discovery, manifest loading, recursive JSON resource loading, JSON5 parsing, selection, and manifest filtering into `KibanaBundle<S: BundleSource>`.
+- [x] 2.2 Implement `read_all` and `read` once for all readable bundle sources.
+- [x] 2.3 Implement `open`, `create`, `root`, and `write` only for `KibanaBundle<Filesystem>` while preserving the stable layout and filesystem safety checks.
+- [x] 2.4 Implement `from_entries` only for `KibanaBundle<Entries<B>>` without filesystem access or temporary materialization.
+- [x] 2.5 Add tests covering generic reads, manifest ordering, missing-resource errors, explicit selections, and source-specific method behavior.
 
 ## 3. Public API and Consumer Migration
 
-- [ ] 3.1 Export `KibanaBundle`, `Filesystem`, and `Entries<B>` from `kibana-sync` and remove the `KibanaFsBundle` public type.
-- [ ] 3.2 Migrate all `kibana-object-manager` filesystem bundle call sites to `KibanaBundle<Filesystem>`.
-- [ ] 3.3 Verify ESDiag can construct `KibanaBundle<Entries<B>>` directly from its in-memory directory entry type.
-- [ ] 3.4 Add tests for borrowed slices, owned vectors, shared buffers, empty entry bundles, automatic space discovery, selected resources, invalid UTF-8, and path-specific parse errors.
+- [x] 3.1 Export `KibanaBundle`, `Filesystem`, and `Entries<B>` from `kibana-sync` and remove the `KibanaFsBundle` public type.
+- [x] 3.2 Migrate all `kibana-object-manager` filesystem bundle call sites to `KibanaBundle<Filesystem>`.
+- [x] 3.3 Verify an application-defined byte type can construct `KibanaBundle<Entries<B>>` through `AsRef<[u8]>` without a consumer-specific adapter.
+- [x] 3.4 Add tests for borrowed slices, owned vectors, shared buffers, empty entry bundles, automatic space discovery, selected resources, invalid UTF-8, and path-specific parse errors.
 
 ## 4. Source-Neutral Skill Projection
 
-- [ ] 4.1 Separate skill frontmatter, body, referenced-content, and reference-metadata parsing from operating-system directory traversal.
-- [ ] 4.2 Adapt filesystem skill projection to the shared format parser while retaining canonical-root containment and symlink rejection.
-- [ ] 4.3 Implement entry-backed skill discovery from immediate skill directories containing `SKILL.md`, including nested referenced Markdown files and reference metadata.
-- [ ] 4.4 Add tests for skill manifest filtering, missing `SKILL.md`, nested referenced content, metadata path restoration, deterministic ordering, and filesystem/entry value equality.
+- [x] 4.1 Separate skill frontmatter, body, referenced-content, and reference-metadata parsing from operating-system directory traversal.
+- [x] 4.2 Adapt filesystem skill projection to the shared format parser while retaining canonical-root containment and symlink rejection.
+- [x] 4.3 Implement entry-backed skill discovery from immediate skill directories containing `SKILL.md`, including nested referenced Markdown files and reference metadata.
+- [x] 4.4 Add tests for skill manifest filtering, missing `SKILL.md`, nested referenced content, metadata path restoration, deterministic ordering, and filesystem/entry value equality.
 
 ## 5. Parity and Documentation
 
-- [ ] 5.1 Create a shared representative bundle fixture covering spaces, every supported resource family, manifests, nested objects, JSON5, skills, and referenced content.
-- [ ] 5.2 Add conformance tests asserting `KibanaBundle<Filesystem>` and `KibanaBundle<Entries<&[u8]>>` `read_all` results are equal for the shared fixture.
-- [ ] 5.3 Add conformance tests asserting filesystem and entry-backed selected reads and validation failures are behaviorally equivalent.
-- [ ] 5.4 Document generic filesystem, `include_bytes!`, and dynamically collected in-memory usage in crate docs or the `kibana-sync` README.
+- [x] 5.1 Create a shared representative bundle fixture covering spaces, every supported resource family, manifests, nested objects, JSON5, skills, and referenced content.
+- [x] 5.2 Add conformance tests asserting `KibanaBundle<Filesystem>` and `KibanaBundle<Entries<&[u8]>>` `read_all` results are equal for the shared fixture.
+- [x] 5.3 Add conformance tests asserting filesystem and entry-backed selected reads and validation failures are behaviorally equivalent.
+- [x] 5.4 Document generic filesystem, `include_bytes!`, and dynamically collected in-memory usage in crate docs or the `kibana-sync` README.
 
 ## 6. Verification
 
-- [ ] 6.1 Run `cargo fmt --all` and verify formatting.
-- [ ] 6.2 Run `cargo clippy --workspace --all-targets -- -D warnings` and resolve warnings.
-- [ ] 6.3 Run `cargo test --workspace` and confirm all unit, integration, conformance, and documentation tests pass.
+- [x] 6.1 Run `cargo fmt --all` and verify formatting.
+- [x] 6.2 Run `cargo clippy --workspace --all-targets -- -D warnings` and resolve warnings.
+- [x] 6.3 Run `cargo test --workspace` and confirm all unit, integration, conformance, and documentation tests pass.


### PR DESCRIPTION
Summary:

- Replace the filesystem-only bundle reader with generic filesystem and entry-backed sources.
- Support validated in-memory bundle entries, JSON5 resources, manifest filtering, and complete skill-directory projection without temporary files.
- Bump kibana-sync to 0.2.3 and complete the embedded-assets OpenSpec tasks.

Verification:

- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace: 295 passed, 10 ignored
- openspec validate embedded-assets --strict