### PR TITLE
fix: simplify skill reference storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,7 +717,7 @@ dependencies = [
 
 [[package]]
 name = "kibana-sync"
-version = "0.2.3"
+version = "0.3.0"
 dependencies = [
  "base64",
  "json5",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -693,7 +693,7 @@ dependencies = [
 
 [[package]]
 name = "kibana-object-manager"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "clap",
  "dotenvy",

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ default/
 
 `manifest/skills.yml` lists the tracked Skills for the space by `id` and `name`. Skill directory names use the Kibana Skill `id` directly; Kibana requires IDs to start and end with a lowercase letter or number and contain only lowercase letters, numbers, hyphens, and underscores. The frontmatter `id` remains authoritative. When the manifest exists, `push` and `togo` include only the listed Skills in manifest order; when it is absent, all `skills/*/SKILL.md` directories are discovered.
 
-`SKILL.md` contains YAML frontmatter with `id`, `name`, `description`, `tool_ids`, and `experimental`; the markdown body is the API `content` field. Additional `.md` files under the skill directory become `referenced_content` entries when bundling or pushing: the filename without `.md` becomes `name`, the parent directory becomes `relativePath` (`examples/query.md` is projected as `./examples`), and the file contents become `content`. The `experimental` field is preserved locally but omitted from create/update API requests because Kibana 9.4 rejects it in request bodies.
+`SKILL.md` contains YAML frontmatter with `id`, `name`, `description`, `tool_ids`, and `experimental`; the markdown body is the API `content` field. Every other file under the skill directory becomes a `referenced_content` entry when bundling or pushing: its filename without the extension becomes `name`, its parent directory becomes `relativePath` (`examples/query.json` is projected as `./examples`), and its contents become `content`. The `experimental` field is preserved locally but omitted from create/update API requests because Kibana 9.4 rejects it in request bodies.
 
 ### 4. Version control with Git
 

--- a/crates/kibana-object-manager/Cargo.toml
+++ b/crates/kibana-object-manager/Cargo.toml
@@ -30,7 +30,7 @@ path = "src/main.rs"
 clap = { version = "^4.5", features = ["derive"] }
 dotenvy = "^0.15"
 eyre = "^0.6"
-kibana-sync = { version = "0.2.3", path = "../kibana-sync" }
+kibana-sync = { version = "0.3.0", path = "../kibana-sync" }
 log = "^0.4"
 owo-colors = "4.2.0"
 regex = "^1.12"

--- a/crates/kibana-object-manager/Cargo.toml
+++ b/crates/kibana-object-manager/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kibana-object-manager"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2024"
 default-run = "kibob"
 rust-version = "1.89"

--- a/crates/kibana-object-manager/src/main.rs
+++ b/crates/kibana-object-manager/src/main.rs
@@ -258,7 +258,7 @@ enum Commands {
     /// Skills are experimental as of Kibana 9.4 and are stored as
     /// skills/{skill-directory}/SKILL.md with YAML frontmatter fields:
     /// id, name, description, tool_ids, and experimental.
-    /// Referenced content is projected from sibling markdown files.
+    /// Referenced content is projected from all files under the skill directory.
     /// Local experimental metadata is omitted from API create/update bodies.
     ///
     /// Examples:

--- a/crates/kibana-sync/Cargo.toml
+++ b/crates/kibana-sync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kibana-sync"
-version = "0.2.3"
+version = "0.3.0"
 edition = "2024"
 rust-version = "1.89"
 authors = ["Ryan Eno"]

--- a/crates/kibana-sync/src/bundle.rs
+++ b/crates/kibana-sync/src/bundle.rs
@@ -3,7 +3,7 @@
 use crate::kibana::agents::AgentsManifest;
 use crate::kibana::saved_objects::SavedObjectsManifest;
 use crate::kibana::skills::{
-    REFERENCED_CONTENT_METADATA_FILE, SKILL_FILE, SkillsManifest, skill_files_to_value,
+    SKILL_FILE, SkillsManifest, skill_files_to_value,
 };
 use crate::kibana::spaces::{SpaceEntry, SpacesManifest};
 use crate::kibana::tools::ToolsManifest;
@@ -323,17 +323,9 @@ impl<S: BundleSource> KibanaBundle<S> {
             }
             self.source.validate_skill_directory(&directory)?;
             let skill_markdown = self.read_text(&skill_file, "skill file")?;
-            let metadata_path = directory.join(REFERENCED_CONTENT_METADATA_FILE);
-            let metadata = self
-                .source
-                .is_file(&metadata_path)
-                .then(|| self.read_text(&metadata_path, "referenced content metadata"))
-                .transpose()?;
             let mut referenced = Vec::new();
             for file in self.source.files_under(&directory)? {
-                if file.extension().and_then(|value| value.to_str()) != Some("md")
-                    || file.file_name().and_then(|value| value.to_str()) == Some(SKILL_FILE)
-                {
+                if file.file_name().and_then(|value| value.to_str()) == Some(SKILL_FILE) {
                     continue;
                 }
                 let relative = file
@@ -350,7 +342,6 @@ impl<S: BundleSource> KibanaBundle<S> {
             values.push(skill_files_to_value(
                 &skill_markdown,
                 referenced,
-                metadata.as_deref(),
                 true,
             )?);
         }
@@ -876,9 +867,8 @@ mod tests {
             ("default/tools/tool.json", r#"{"id":"tool-1","name":"Tool"}"#),
             ("default/manifest/skills.yml", "skills:\n  - id: skill-1\n    name: Skill\n"),
             ("default/skills/skill-1/SKILL.md", "---\nid: skill-1\nname: Skill\ntool_ids:\n  - tool-1\n---\nInstructions\n"),
-            ("default/skills/skill-1/aaa/query.md", "Query body\n"),
-            ("default/skills/skill-1/zzz/intro.md", "Intro body\n"),
-            ("default/skills/skill-1/.referenced_content.yml", "entries:\n  - path: aaa/query.md\n    name: Query Reference\n    relativePath: ./references\n  - path: zzz/intro.md\n    name: Intro Reference\n    relativePath: ./examples\n"),
+            ("default/skills/skill-1/references/query.txt", "Query body\n"),
+            ("default/skills/skill-1/examples/intro.yml", "Intro body\n"),
         ]
         .into_iter()
         .map(|(path, content)| (path.to_string(), content.as_bytes().to_vec()))
@@ -922,9 +912,9 @@ mod tests {
         let referenced = owned.by_space["default"].skills[0]["referenced_content"]
             .as_array()
             .unwrap();
-        assert_eq!(referenced[0]["name"], "Intro Reference");
+        assert_eq!(referenced[0]["name"], "intro");
         assert_eq!(referenced[0]["relativePath"], "./examples");
-        assert_eq!(referenced[1]["name"], "Query Reference");
+        assert_eq!(referenced[1]["name"], "query");
         assert_eq!(referenced[1]["relativePath"], "./references");
 
         let application = KibanaBundle::from_entries(

--- a/crates/kibana-sync/src/kibana/skills/mod.rs
+++ b/crates/kibana-sync/src/kibana/skills/mod.rs
@@ -10,7 +10,7 @@ mod storage;
 pub use extractor::{SkillsExtractor, parse_skills_response};
 pub use loader::SkillsLoader;
 pub use manifest::{SkillEntry, SkillsManifest};
-pub(crate) use storage::{REFERENCED_CONTENT_METADATA_FILE, SKILL_FILE, skill_files_to_value};
+pub(crate) use storage::{SKILL_FILE, skill_files_to_value};
 pub use storage::{
     ReferencedContent, SkillFrontmatter, read_skill_directory, sanitize_path_component,
     skill_directory_name, skill_to_directory, skill_to_value,

--- a/crates/kibana-sync/src/kibana/skills/storage.rs
+++ b/crates/kibana-sync/src/kibana/skills/storage.rs
@@ -9,7 +9,6 @@ use std::{
 };
 
 pub(crate) const SKILL_FILE: &str = "SKILL.md";
-pub(crate) const REFERENCED_CONTENT_METADATA_FILE: &str = ".referenced_content.yml";
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct SkillFrontmatter {
@@ -51,20 +50,6 @@ pub struct SkillDirectory {
     pub frontmatter: SkillFrontmatter,
     pub content: String,
     pub referenced_content: Vec<ReferencedContent>,
-}
-
-#[derive(Debug, Default, Serialize, Deserialize)]
-struct ReferencedContentMetadata {
-    #[serde(default)]
-    entries: Vec<ReferencedContentMetadataEntry>,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-struct ReferencedContentMetadataEntry {
-    path: String,
-    name: String,
-    #[serde(rename = "relativePath")]
-    relative_path: String,
 }
 
 impl SkillDirectory {
@@ -198,7 +183,7 @@ pub fn read_skill_directory(directory: &Path) -> Result<SkillDirectory> {
     let content = std::fs::read_to_string(&skill_file)
         .with_context(|| format!("Failed to read skill file: {}", skill_file.display()))?;
     let mut files = Vec::new();
-    collect_markdown_files(&canonical_directory, directory, &mut files)?;
+    collect_reference_files(&canonical_directory, directory, &mut files)?;
     files.sort();
     let referenced_files = files
         .into_iter()
@@ -218,50 +203,7 @@ pub fn read_skill_directory(directory: &Path) -> Result<SkillDirectory> {
             Ok((relative, content))
         })
         .collect::<Result<Vec<_>>>()?;
-    let metadata_path = directory.join(REFERENCED_CONTENT_METADATA_FILE);
-    let metadata = match std::fs::symlink_metadata(&metadata_path) {
-        Ok(_) => {
-            validate_file_within_directory(&canonical_directory, &metadata_path)?;
-            Some(std::fs::read_to_string(&metadata_path).with_context(|| {
-                format!(
-                    "Failed to read referenced content metadata: {}",
-                    metadata_path.display()
-                )
-            })?)
-        }
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
-        Err(error) => {
-            return Err(error).with_context(|| {
-                format!(
-                    "Failed to inspect referenced content metadata: {}",
-                    metadata_path.display()
-                )
-            });
-        }
-    };
-
-    skill_files_to_directory(&content, referenced_files, metadata.as_deref())
-}
-
-fn validate_file_within_directory(canonical_directory: &Path, path: &Path) -> Result<()> {
-    let metadata = std::fs::symlink_metadata(path)
-        .with_context(|| format!("Failed to inspect path: {}", path.display()))?;
-    if metadata.file_type().is_symlink() {
-        return Err(Error::message(format!(
-            "path uses symlink traversal inside skill directory: {}",
-            path.display()
-        )));
-    }
-    let canonical = path
-        .canonicalize()
-        .with_context(|| format!("Failed to resolve path: {}", path.display()))?;
-    if !canonical.starts_with(canonical_directory) {
-        return Err(Error::message(format!(
-            "path escapes skill directory: {}",
-            path.display()
-        )));
-    }
-    Ok(())
+    skill_files_to_directory(&content, referenced_files)
 }
 
 pub fn skill_to_value(directory: &Path, include_id: bool) -> Result<Value> {
@@ -271,47 +213,27 @@ pub fn skill_to_value(directory: &Path, include_id: bool) -> Result<Value> {
 pub(crate) fn skill_files_to_value(
     skill_markdown: &str,
     referenced_files: impl IntoIterator<Item = (PathBuf, String)>,
-    metadata_yaml: Option<&str>,
     include_id: bool,
 ) -> Result<Value> {
-    Ok(
-        skill_files_to_directory(skill_markdown, referenced_files, metadata_yaml)?
-            .to_value(include_id),
-    )
+    Ok(skill_files_to_directory(skill_markdown, referenced_files)?.to_value(include_id))
 }
 
 fn skill_files_to_directory(
     skill_markdown: &str,
     referenced_files: impl IntoIterator<Item = (PathBuf, String)>,
-    metadata_yaml: Option<&str>,
 ) -> Result<SkillDirectory> {
     let (frontmatter, body) = parse_skill_markdown(skill_markdown)?;
-    let metadata = metadata_yaml
-        .map(|content| {
-            yaml_serde::from_str(content).context("Failed to parse referenced content metadata")
-        })
-        .transpose()?
-        .unwrap_or_default();
     let mut referenced_content = referenced_files
         .into_iter()
         .map(|(relative, content)| {
             let parent = relative.parent().unwrap_or_else(|| Path::new(""));
-            let metadata_entry = metadata_entry_for(&metadata, &relative)?;
-            let relative_path = metadata_entry
-                .map(|entry| entry.relative_path.clone())
-                .unwrap_or_else(|| path_to_api_relative_path(parent));
-            let name = if let Some(entry) = metadata_entry {
-                entry.name.clone()
-            } else {
-                relative
+            Ok(ReferencedContent {
+                name: relative
                     .file_stem()
                     .and_then(|stem| stem.to_str())
                     .ok_or_else(|| Error::message("referenced content filename is not UTF-8"))?
-                    .to_string()
-            };
-            Ok(ReferencedContent {
-                name,
-                relative_path,
+                    .to_string(),
+                relative_path: path_to_api_relative_path(parent),
                 content,
             })
         })
@@ -444,7 +366,6 @@ fn parse_skill_markdown(markdown: &str) -> Result<(SkillFrontmatter, &str)> {
 }
 
 fn write_referenced_content(root: &Path, entries: &[ReferencedContent]) -> Result<()> {
-    let mut metadata = ReferencedContentMetadata::default();
     let mut seen_paths = BTreeSet::new();
 
     for entry in entries {
@@ -452,11 +373,11 @@ fn write_referenced_content(root: &Path, entries: &[ReferencedContent]) -> Resul
         let sanitized_name = sanitize_path_component(&entry.name);
         let file_name = format!("{sanitized_name}.md");
         let relative_file = relative_dir.join(file_name);
-        let metadata_path = metadata_path_for(&relative_file)?;
-        let comparable_metadata_path = metadata_path.to_lowercase();
+        let comparable_metadata_path = relative_file.to_string_lossy().to_lowercase();
         if !seen_paths.insert(comparable_metadata_path) {
             return Err(Error::message(format!(
-                "duplicate referenced content path after sanitization: {metadata_path}"
+                "duplicate referenced content path after sanitization: {}",
+                relative_file.display()
             )));
         }
 
@@ -472,50 +393,11 @@ fn write_referenced_content(root: &Path, entries: &[ReferencedContent]) -> Resul
         }
         std::fs::write(&path, &entry.content)
             .with_context(|| format!("Failed to write referenced content: {}", path.display()))?;
-
-        let normalized_relative_path = normalize_api_relative_path(&entry.relative_path)?;
-        let derived_relative_path = path_to_api_relative_path(&relative_dir);
-        if sanitized_name != entry.name || derived_relative_path != normalized_relative_path {
-            metadata.entries.push(ReferencedContentMetadataEntry {
-                path: metadata_path,
-                name: entry.name.clone(),
-                relative_path: normalized_relative_path,
-            });
-        }
     }
-
-    write_referenced_content_metadata(root, &metadata)?;
     Ok(())
 }
 
-fn write_referenced_content_metadata(
-    root: &Path,
-    metadata: &ReferencedContentMetadata,
-) -> Result<()> {
-    if metadata.entries.is_empty() {
-        return Ok(());
-    }
-
-    let path = root.join(REFERENCED_CONTENT_METADATA_FILE);
-    let yaml = yaml_serde::to_string(metadata)
-        .context("Failed to serialize referenced content metadata")?;
-    std::fs::write(&path, yaml).with_context(|| {
-        format!(
-            "Failed to write referenced content metadata: {}",
-            path.display()
-        )
-    })
-}
-
-fn metadata_entry_for<'a>(
-    metadata: &'a ReferencedContentMetadata,
-    relative: &Path,
-) -> Result<Option<&'a ReferencedContentMetadataEntry>> {
-    let path = metadata_path_for(relative)?;
-    Ok(metadata.entries.iter().find(|entry| entry.path == path))
-}
-
-fn collect_markdown_files(
+fn collect_reference_files(
     canonical_root: &Path,
     directory: &Path,
     files: &mut Vec<PathBuf>,
@@ -543,10 +425,8 @@ fn collect_markdown_files(
         }
 
         if metadata.is_dir() {
-            collect_markdown_files(canonical_root, &path, files)?;
-        } else if path.extension().and_then(|extension| extension.to_str()) == Some("md")
-            && path.file_name().and_then(|name| name.to_str()) != Some(SKILL_FILE)
-        {
+            collect_reference_files(canonical_root, &path, files)?;
+        } else if path.file_name().and_then(|name| name.to_str()) != Some(SKILL_FILE) {
             files.push(path);
         }
     }
@@ -603,58 +483,6 @@ fn safe_relative_dir(relative_path: &str) -> Result<PathBuf> {
     }
 
     Ok(path)
-}
-
-fn normalize_api_relative_path(relative_path: &str) -> Result<String> {
-    let mut parts = Vec::new();
-    if relative_path.is_empty() {
-        return Ok(String::new());
-    }
-
-    for component in Path::new(relative_path).components() {
-        match component {
-            Component::Normal(value) => {
-                let value = value
-                    .to_str()
-                    .ok_or_else(|| Error::message("relativePath contains non-UTF-8 data"))?;
-                parts.push(value);
-            }
-            Component::CurDir => {}
-            _ => {
-                return Err(Error::message(format!(
-                    "unsafe referenced content relativePath: {relative_path}"
-                )));
-            }
-        }
-    }
-
-    if parts.is_empty() {
-        Ok(String::new())
-    } else {
-        Ok(format!("./{}", parts.join("/")))
-    }
-}
-
-fn metadata_path_for(relative: &Path) -> Result<String> {
-    let mut parts = Vec::new();
-    for component in relative.components() {
-        match component {
-            Component::Normal(value) => {
-                let value = value
-                    .to_str()
-                    .ok_or_else(|| Error::message("referenced content path is not UTF-8"))?;
-                parts.push(value);
-            }
-            _ => {
-                return Err(Error::message(format!(
-                    "unsafe referenced content path: {}",
-                    relative.display()
-                )));
-            }
-        }
-    }
-
-    Ok(parts.join("/"))
 }
 
 fn path_to_api_relative_path(path: &Path) -> String {
@@ -739,7 +567,10 @@ mod tests {
         assert!(dir.join("SKILL.md").exists());
         assert!(dir.join("overview.md").exists());
         assert!(dir.join("examples/query.md").exists());
-        assert!(!dir.join(REFERENCED_CONTENT_METADATA_FILE).exists());
+        assert_eq!(
+            std::fs::read_to_string(dir.join("overview.md")).unwrap(),
+            "Root ref\n"
+        );
 
         let read = read_skill_directory(&dir).unwrap();
         assert_eq!(read.frontmatter.id, "threat-hunting-copy");
@@ -844,7 +675,7 @@ mod tests {
     }
 
     #[test]
-    fn preserves_referenced_content_values_when_paths_are_sanitized() {
+    fn derives_referenced_content_values_from_sanitized_paths() {
         let temp = TempDir::new().unwrap();
         let skill = json!({
             "id": "sanitize-skill",
@@ -862,15 +693,42 @@ mod tests {
         let dir = skill_to_directory(temp.path(), &skill).unwrap();
 
         assert!(dir.join("examples_prod/query_prod.md").exists());
-        assert!(dir.join(REFERENCED_CONTENT_METADATA_FILE).exists());
+        assert_eq!(
+            std::fs::read_to_string(dir.join("examples_prod/query_prod.md")).unwrap(),
+            "from logs\n"
+        );
 
         let projected = skill_to_value(&dir, true).unwrap();
-        assert_eq!(projected["referenced_content"][0]["name"], "query:prod");
+        assert_eq!(projected["referenced_content"][0]["name"], "query_prod");
         assert_eq!(
             projected["referenced_content"][0]["relativePath"],
-            "./examples:prod"
+            "./examples_prod"
         );
         assert_eq!(projected["referenced_content"][0]["content"], "from logs\n");
+    }
+
+    #[test]
+    fn collects_non_markdown_referenced_content() {
+        let temp = TempDir::new().unwrap();
+        let skill_dir = temp.path().join("skill");
+        std::fs::create_dir(&skill_dir).unwrap();
+        std::fs::write(
+            skill_dir.join(SKILL_FILE),
+            "---\nid: skill\nname: Skill\n---\nInstructions\n",
+        )
+        .unwrap();
+        std::fs::create_dir(skill_dir.join("examples")).unwrap();
+        std::fs::write(skill_dir.join("examples/query.json"), r#"{"query":"*"}"#).unwrap();
+        std::fs::write(skill_dir.join("notes.txt"), "Notes\n").unwrap();
+
+        let projected = skill_to_value(&skill_dir, true).unwrap();
+
+        assert_eq!(projected["referenced_content"].as_array().unwrap().len(), 2);
+        assert_eq!(projected["referenced_content"][0]["name"], "notes");
+        assert_eq!(projected["referenced_content"][0]["relativePath"], "");
+        assert_eq!(projected["referenced_content"][1]["name"], "query");
+        assert_eq!(projected["referenced_content"][1]["relativePath"], "./examples");
+        assert_eq!(projected["referenced_content"][1]["content"], r#"{"query":"*"}"#);
     }
 
     #[test]
@@ -958,20 +816,6 @@ mod tests {
             err.to_string()
                 .contains("skill directory cannot be a symlink")
         );
-    }
-
-    #[test]
-    fn rejects_referenced_content_metadata_symlink_escape() {
-        let temp = TempDir::new().unwrap();
-        let skill_dir = temp.path().join("skill");
-        std::fs::create_dir(&skill_dir).unwrap();
-        std::fs::write(skill_dir.join(SKILL_FILE), "---\nid: skill\n---\nBody\n").unwrap();
-        let outside = temp.path().join("missing-metadata.yml");
-        symlink_file(&outside, &skill_dir.join(REFERENCED_CONTENT_METADATA_FILE)).unwrap();
-
-        let err = read_skill_directory(&skill_dir).unwrap_err();
-
-        assert!(err.to_string().contains("symlink traversal"));
     }
 
     #[test]

--- a/openspec/changes/embedded-assets/design.md
+++ b/openspec/changes/embedded-assets/design.md
@@ -1,6 +1,6 @@
 ## Context
 
-`KibanaFsBundle` currently combines two responsibilities: access to an operating-system directory tree and interpretation of the Kibana bundle layout. Its read path calls `Path::exists`, `std::fs::read_dir`, and `std::fs::read_to_string` directly, while skill projection expects a real skill directory so it can discover `SKILL.md` and referenced Markdown files. This prevents ESDiag and similar consumers from loading assets exposed as relative paths and bytes without first creating a temporary directory or duplicating the layout parser.
+`KibanaFsBundle` currently combines two responsibilities: access to an operating-system directory tree and interpretation of the Kibana bundle layout. Its read path calls `Path::exists`, `std::fs::read_dir`, and `std::fs::read_to_string` directly, while skill projection expects a real skill directory so it can discover `SKILL.md` and referenced files. This prevents ESDiag and similar consumers from loading assets exposed as relative paths and bytes without first creating a temporary directory or duplicating the layout parser.
 
 The established behavior is broader than parsing JSON files. The reader discovers spaces from `spaces.yml` and space directories, honors per-space manifests as ordering and selection authorities, recursively parses JSON5 resources, validates manifest references, and converts complete skill directory trees into Kibana values. The stable layout and parsing behavior must remain intact, but `KibanaFsBundle` source compatibility is unnecessary because the only two consumers are this workspace and ESDiag, both of which can migrate before the first public release.
 
@@ -21,7 +21,7 @@ The change affects only the extraction side of the sync ETL pipeline. `SyncBundl
 **Goals:**
 - Load a complete Kibana asset bundle from relative-path and byte-content entries without filesystem materialization.
 - Produce the same `SyncBundle` content, ordering, selection behavior, and validation outcomes as filesystem reads.
-- Preserve JSON5 support and complete skill projection, including nested referenced content and its metadata.
+- Preserve JSON5 support and complete skill projection, including nested referenced files.
 - Provide one generic `KibanaBundle<S>` API with compile-time backend capabilities.
 - Keep filesystem bundle layout and read/write behavior while allowing both consumers to migrate to the generic API.
 - Reject paths that could escape the entry root or make lookup ambiguous.
@@ -84,7 +84,7 @@ Alternative considered: silently clean `.` and `..` components. Rejected because
 
 ### 4) Parse text from bytes at the source-neutral boundary
 
-Manifest, JSON5, `SKILL.md`, referenced-content Markdown, and skill metadata readers decode required text files as UTF-8 and attach the normalized logical path to parse and decoding errors. JSON resources retain the current recursive `.json` discovery, lexicographic ordering, and `json5::from_json5_str` behavior. YAML and JSON manifests continue using their existing schemas and source-of-truth semantics.
+Manifest, JSON5, `SKILL.md`, and referenced-content readers decode required text files as UTF-8 and attach the normalized logical path to parse and decoding errors. JSON resources retain the current recursive `.json` discovery, lexicographic ordering, and `json5::from_json5_str` behavior. YAML and JSON manifests continue using their existing schemas and source-of-truth semantics.
 
 Rationale: byte entries support normal embedding APIs while explicit UTF-8 validation preserves the text formats' current expectations and provides useful diagnostics.
 
@@ -92,7 +92,7 @@ Alternative considered: require entry content as `str`. Rejected because common 
 
 ### 5) Project skills directly from their logical directory tree
 
-Extract the format-level portions of `skill_to_value` so they can consume a logical skill directory and its text entries rather than requiring `Path::canonicalize` and `std::fs` traversal. A skill is discoverable only when an immediate child of `<space>/skills/` contains `SKILL.md`. Nested Markdown referenced content and the existing reference metadata file are read using normalized relative paths, with the same ordering, names, relative paths, and validation as filesystem projection.
+Extract the format-level portions of `skill_to_value` so they can consume a logical skill directory and its text entries rather than requiring `Path::canonicalize` and `std::fs` traversal. A skill is discoverable only when an immediate child of `<space>/skills/` contains `SKILL.md`. Every other nested file is referenced content: the filesystem-safe filename stem is its API name and its parent directory determines its API relative path. No metadata sidecar or path override is accepted.
 
 Filesystem projection continues to enforce canonical-root containment and reject symlinked skill directories or referenced content. Entry-backed sources cannot contain symlinks, so their equivalent safety guarantee comes from constructor path validation.
 
@@ -102,7 +102,7 @@ Alternative considered: represent each skill as a prebuilt Kibana JSON value in 
 
 ### 6) Verify parity with source conformance fixtures
 
-Build one representative bundle fixture containing spaces, manifests, nested saved objects, workflows, agents, tools, JSON5 syntax, skills, reference metadata, and nested referenced content. Load it through `KibanaBundle<Filesystem>` and `KibanaBundle<Entries<&[u8]>>`, then assert equal `SyncBundle` results for `read_all` and representative selections. Add entry-only tests for invalid paths, duplicates, invalid UTF-8 in selected text assets, missing manifest resources, deterministic ordering, and empty bundles.
+Build one representative bundle fixture containing spaces, manifests, nested saved objects, workflows, agents, tools, JSON5 syntax, skills, and nested referenced files. Load it through `KibanaBundle<Filesystem>` and `KibanaBundle<Entries<&[u8]>>`, then assert equal `SyncBundle` results for `read_all` and representative selections. Add entry-only tests for invalid paths, duplicates, invalid UTF-8 in selected text assets, missing manifest resources, deterministic ordering, and empty bundles.
 
 Rationale: parity is the primary compatibility promise and is stronger when exercised against identical logical content.
 

--- a/openspec/changes/embedded-assets/proposal.md
+++ b/openspec/changes/embedded-assets/proposal.md
@@ -7,7 +7,7 @@ Embedded consumers such as ESDiag cannot use `KibanaFsBundle` without first mate
 - **BREAKING** Replace `KibanaFsBundle` with a generic `KibanaBundle<S>` whose backend determines its available operations.
 - Add a `Filesystem` backend for path-backed bundle reads and writes and an `Entries<B>` backend for embedded `(relative path, bytes)` assets where `B: AsRef<[u8]>`.
 - Share bundle discovery, manifest parsing, resource selection, JSON5 parsing, ordering, and validation across both generic backends.
-- Preserve complete skill-directory loading, including `SKILL.md`, referenced-content subdirectories, and reference metadata, without requiring real directories.
+- Preserve complete skill-directory loading, including `SKILL.md` and referenced-content subdirectories, without requiring real directories. Referenced files use filesystem-safe names and derive their API names and relative paths from their location.
 - Reject unsafe, invalid, or ambiguous entry paths with actionable library errors.
 - Document the generic API, migrate both consumers, and test behavioral parity between filesystem-backed and entry-backed reads.
 

--- a/openspec/changes/embedded-assets/specs/kibana-sync/spec.md
+++ b/openspec/changes/embedded-assets/specs/kibana-sync/spec.md
@@ -34,10 +34,10 @@ The `kibana-sync` crate SHALL expose `KibanaBundle<S>` with a `Filesystem` sourc
 - **AND** any decode or parse error identifies the resource's logical relative path
 
 #### Scenario: Load a complete virtual skill directory
-- **GIVEN** an entry-backed skill directory containing `SKILL.md`, nested referenced Markdown content, and reference metadata
+- **GIVEN** an entry-backed skill directory containing `SKILL.md` and nested referenced files with filesystem-safe names
 - **WHEN** the bundle is read with skills enabled
 - **THEN** the library projects the skill and its referenced content into the same Kibana value produced from the equivalent filesystem directory
-- **AND** preserves referenced-content names, relative paths, content, and deterministic ordering
+- **AND** derives referenced-content names from filename stems and relative paths from the directory structure, with deterministic ordering
 
 #### Scenario: Discover spaces from virtual layout
 - **GIVEN** an entry-backed bundle with space entries in `spaces.yml` and a space directory containing supported resources but absent from that manifest

--- a/openspec/changes/embedded-assets/tasks.md
+++ b/openspec/changes/embedded-assets/tasks.md
@@ -23,10 +23,10 @@
 
 ## 4. Source-Neutral Skill Projection
 
-- [x] 4.1 Separate skill frontmatter, body, referenced-content, and reference-metadata parsing from operating-system directory traversal.
+- [x] 4.1 Separate skill frontmatter, body, and referenced-content parsing from operating-system directory traversal.
 - [x] 4.2 Adapt filesystem skill projection to the shared format parser while retaining canonical-root containment and symlink rejection.
-- [x] 4.3 Implement entry-backed skill discovery from immediate skill directories containing `SKILL.md`, including nested referenced Markdown files and reference metadata.
-- [x] 4.4 Add tests for skill manifest filtering, missing `SKILL.md`, nested referenced content, metadata path restoration, deterministic ordering, and filesystem/entry value equality.
+- [x] 4.3 Implement entry-backed skill discovery from immediate skill directories containing `SKILL.md`, including nested referenced files.
+- [x] 4.4 Add tests for skill manifest filtering, missing `SKILL.md`, nested referenced content, filesystem-derived names and relative paths, deterministic ordering, and filesystem/entry value equality.
 
 ## 5. Parity and Documentation
 


### PR DESCRIPTION
## Summary
- derive Skill reference names and relative paths strictly from filesystem-safe paths
- include non-Markdown reference files in filesystem and embedded bundle readers
- align the embedded-assets OpenSpec artifacts with the finalized reference-file model

## Verification
- 
running 20 tests
test bundle::tests::bundle_reader_rejects_path_traversal_space_ids ... ok
test bundle::tests::filesystem_write_rejects_non_object_spaces ... ok
test bundle::tests::filesystem_bundle_roots_cannot_be_symlinks ... ok
test bundle::tests::filesystem_sources_reject_symlink_traversal ... ok
test bundle::tests::entry_paths_are_validated_and_directories_are_implicit ... ok
test bundle::tests::entry_files_under_does_not_stop_at_lexicographic_siblings ... ok
test bundle::tests::bundle_reader_rejects_manifest_directories ... ok
test bundle::tests::entry_errors_include_logical_paths ... ok
test bundle::tests::manifest_parse_errors_include_logical_paths ... ok
test bundle::tests::filesystem_write_rejects_path_traversal_space_ids ... ok
test bundle::tests::bundle_reader_rejects_path_traversal_space_manifest_ids ... ok
test bundle::tests::space_definitions_preserve_full_space_configuration ... ok
test bundle::tests::space_definitions_default_missing_name_from_manifest ... ok
test bundle::tests::empty_bundle_and_implicit_spaces_are_supported ... ok
test bundle::tests::entry_sources_support_owned_borrowed_and_shared_bytes ... ok
test bundle::tests::filesystem_write_defaults_space_definition_name ... ok
test bundle::tests::missing_manifest_resources_report_logical_directory ... ok
test bundle::tests::filesystem_and_entries_have_read_parity ... ok
test bundle::tests::selection_and_manifest_order_match_filesystem_behavior ... ok
test bundle::tests::filesystem_write_round_trips_through_generic_reader ... ok

test result: ok. 20 passed; 0 failed; 0 ignored; 0 measured; 119 filtered out; finished in 0.02s
- 
running 16 tests
test kibana::skills::storage::tests::rejects_uppercase_skill_ids ... ok
test kibana::skills::storage::tests::rejects_invalid_skill_ids ... ok
test kibana::skills::storage::tests::skill_directory_name_uses_valid_skill_id_directly ... ok
test kibana::skills::storage::tests::missing_frontmatter_id_is_missing_resource_id ... ok
test kibana::skills::storage::tests::whitespace_frontmatter_id_is_missing_resource_id ... ok
test kibana::skills::storage::tests::parses_crlf_frontmatter_without_changing_body ... ok
test kibana::skills::storage::tests::rejects_parent_relative_path ... ok
test kibana::skills::storage::tests::rejects_case_insensitive_referenced_content_path_collisions ... ok
test kibana::skills::storage::tests::update_projection_omits_id_and_uses_stable_empty_arrays ... ok
test kibana::skills::storage::tests::rejects_skill_file_symlink_escape ... ok
test kibana::skills::storage::tests::rejects_skill_directory_symlink ... ok
test kibana::skills::storage::tests::rejects_referenced_content_symlink_directory ... ok
test kibana::skills::storage::tests::rewrites_skill_directory_without_stale_referenced_content ... ok
test kibana::skills::storage::tests::derives_referenced_content_values_from_sanitized_paths ... ok
test kibana::skills::storage::tests::collects_non_markdown_referenced_content ... ok
test kibana::skills::storage::tests::writes_and_reads_skill_directory ... ok

test result: ok. 16 passed; 0 failed; 0 ignored; 0 measured; 123 filtered out; finished in 0.01s