### PR TITLE
fix(kibana-sync): load dependencies in order

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,7 +717,7 @@ dependencies = [
 
 [[package]]
 name = "kibana-sync"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "base64",
  "json5",

--- a/crates/kibana-sync/Cargo.toml
+++ b/crates/kibana-sync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kibana-sync"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 rust-version = "1.89"
 authors = ["Ryan Eno"]

--- a/crates/kibana-sync/src/sync.rs
+++ b/crates/kibana-sync/src/sync.rs
@@ -394,6 +394,13 @@ pub async fn push_sync(
                 .await?;
         }
 
+        if include_workflows {
+            summary.workflows_attempted += space_bundle.workflows.len();
+            summary.workflows_applied += WorkflowsLoader::new(space_client.clone())
+                .load(space_bundle.workflows.clone())
+                .await?;
+        }
+
         if include_tools {
             summary.tools_attempted += space_bundle.tools.len();
             summary.tools_applied += ToolsLoader::new(space_client.clone())
@@ -412,13 +419,6 @@ pub async fn push_sync(
             summary.agents_attempted += space_bundle.agents.len();
             summary.agents_applied += AgentsLoader::new(space_client.clone())
                 .load(space_bundle.agents.clone())
-                .await?;
-        }
-
-        if include_workflows {
-            summary.workflows_attempted += space_bundle.workflows.len();
-            summary.workflows_applied += WorkflowsLoader::new(space_client)
-                .load(space_bundle.workflows.clone())
                 .await?;
         }
     }
@@ -619,6 +619,110 @@ mod tests {
 
         assert_eq!(plan.supported, vec![ApiCapability::Skills]);
         assert!(plan.unsupported.is_empty());
+    }
+
+    #[tokio::test]
+    async fn push_sync_loads_local_dependencies_before_dependents() {
+        let server = TestServer::new(vec![
+            MockResponse {
+                method: "HEAD",
+                path: "/api/workflows/workflow/workflow-w",
+                status: 404,
+                body: json!({}),
+            },
+            MockResponse {
+                method: "POST",
+                path: "/api/workflows/workflow",
+                status: 200,
+                body: json!({}),
+            },
+            MockResponse {
+                method: "HEAD",
+                path: "/api/agent_builder/tools/tool-t",
+                status: 404,
+                body: json!({}),
+            },
+            MockResponse {
+                method: "POST",
+                path: "/api/agent_builder/tools",
+                status: 200,
+                body: json!({}),
+            },
+            MockResponse {
+                method: "GET",
+                path: "/api/agent_builder/skills/skill-s",
+                status: 404,
+                body: json!({}),
+            },
+            MockResponse {
+                method: "POST",
+                path: "/api/agent_builder/skills",
+                status: 200,
+                body: json!({}),
+            },
+            MockResponse {
+                method: "HEAD",
+                path: "/api/agent_builder/agents/agent-a",
+                status: 404,
+                body: json!({}),
+            },
+            MockResponse {
+                method: "POST",
+                path: "/api/agent_builder/agents",
+                status: 200,
+                body: json!({}),
+            },
+        ]);
+        let bundle = SyncBundle {
+            by_space: HashMap::from([(
+                "default".to_string(),
+                SpaceBundle {
+                    workflows: vec![json!({"id": "workflow-w", "name": "Workflow W"})],
+                    tools: vec![json!({
+                        "id": "tool-t",
+                        "configuration": {"workflow_id": "workflow-w"}
+                    })],
+                    skills: vec![json!({"id": "skill-s", "tool_ids": ["tool-t"]})],
+                    agents: vec![json!({
+                        "id": "agent-a",
+                        "configuration": {"skill_id": "skill-s"}
+                    })],
+                    ..SpaceBundle::default()
+                },
+            )]),
+            ..SyncBundle::default()
+        };
+        let options = SyncOptions {
+            unsupported_api_policy: UnsupportedApiPolicy::Force,
+            ..SyncOptions::default()
+        };
+
+        let summary = push_sync(&server.client().unwrap(), &bundle, &options)
+            .await
+            .unwrap();
+
+        assert_eq!(summary.workflows_applied, 1);
+        assert_eq!(summary.tools_applied, 1);
+        assert_eq!(summary.skills_applied, 1);
+        assert_eq!(summary.agents_applied, 1);
+        let paths = server
+            .requests()
+            .into_iter()
+            .map(|request| request.path)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            paths,
+            vec![
+                "/api/workflows/workflow/workflow-w",
+                "/api/workflows/workflow",
+                "/api/agent_builder/tools/tool-t",
+                "/api/agent_builder/tools",
+                "/api/agent_builder/skills/skill-s",
+                "/api/agent_builder/skills",
+                "/api/agent_builder/agents/agent-a",
+                "/api/agent_builder/agents",
+            ]
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- load workflows before tools, skills, and agents in push_sync
- add a regression test for the workflow -> tool -> skill -> agent chain
- bump kibana-sync to 0.3.1

## Verification

- cargo test -p kibana-sync
- cargo clippy -p kibana-sync --all-targets -- -D warnings